### PR TITLE
Discovery findnode should have hash-sized target

### DIFF
--- a/rlpx.md
+++ b/rlpx.md
@@ -165,7 +165,7 @@ Packet Data (packet-data):
 	FindNeighbours packet-type: 0x03
 	struct FindNeighbours
 	{
-		NodeId target; // Id of a node. The responding node will send back nodes closest to the target.
+		uint8_t target[32]; // the responding node will send back nodes closest to target.
 		uint32_t timestamp;
 	};
 	


### PR DESCRIPTION
This is mostly a performance concern. With a hash-sized target, it does not need to be hashed by the recipient in order to compute the closest nodes.

The other reason why this might be a good change is that calling it a NodeID is wrong in general.
The lookup target is arbitrary and does not need to be a valid EC public key. We could leave it at 64
bytes, but it then needs to be hashed anyway in order to fit into the distance metric.
