### PR TITLE
Fix links for References in rlpx.md

### DIFF
--- a/rlpx.md
+++ b/rlpx.md
@@ -414,11 +414,11 @@ WiP:
 - Go [x] C++ [x] Py [x] Java [x]: AES256 CTR
 
 # References
- - Petar Maymounkov and David Mazieres. Kademlia: A Peer-to-peer Information System Based on the XOR Metric. 2002. URL {https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf}  
- - Victor Shoup. A proposal for an ISO standard for public key encryption, Version 2.1. 2001. URL {http://www.shoup.net/papers/iso-2_1.pdf}  
- - Gavin Wood. libp2p Whitepaper. 2014. URL {https://github.com/ethereum/wiki/wiki/libp2p-Whitepaper}  
- - Mike Belshe and Roberto Peon. SPDY Protocol - Draft 3. 2014. URL {http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3}  
- - Vitalik Buterin. Ethereum: Merkle Patricia Tree Specification. 2014. URL {http://vitalik.ca/ethereum/patricia.html}
+ - Petar Maymounkov and David Mazieres. Kademlia: A Peer-to-peer Information System Based on the XOR Metric. 2002. URL { https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf }  
+ - Victor Shoup. A proposal for an ISO standard for public key encryption, Version 2.1. 2001. URL { http://www.shoup.net/papers/iso-2_1.pdf }  
+ - Gavin Wood. libp2p Whitepaper. 2014. URL { https://github.com/ethereum/wiki/wiki/libp2p-Whitepaper }  
+ - Mike Belshe and Roberto Peon. SPDY Protocol - Draft 3. 2014. URL { http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3 }  
+ - Vitalik Buterin. Ethereum: Merkle Patricia Tree Specification. 2014. URL { http://vitalik.ca/ethereum/patricia.html }
 
 # Contributors
 (Contributors: Please create PR w/name or alias to reference)


### PR DESCRIPTION
Every link in the `References` section has a `}` at the end of it that is encoded as `%7D` when the link is clicked. 

For example, the libp2p whitepaper link takes one to `https://github.com/ethereum/wiki/wiki/libp2p-Whitepaper%7D` which is not the correct url.