### PR TITLE
discv5: add intro document, handshake, more theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ethereum.
 
 * [Node Discovery Protocol v4]
 * [Node Discovery Protocol v5] **(Draft Specification)**
-* The [RLPx transport protocol] (version 5) and several RLPx-based capabilities:
+* [RLPx transport protocol] (version 5) and several RLPx-based capabilities:
   * [Ethereum Wire Protocol] (version 63)
   * [Light Ethereum Subprotocol] (version 2)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository contains specifications for the peer-to-peer networking protocols used by
 Ethereum.
 
-* The [Node Discovery Protocol] (version 4)
+* [Node Discovery Protocol v4]
+* [Node Discovery Protocol v5] **(Draft Specification)**
 * The [RLPx transport protocol] (version 5) and several RLPx-based capabilities:
   * [Ethereum Wire Protocol] (version 63)
   * [Light Ethereum Subprotocol] (version 2)
@@ -68,7 +69,8 @@ devp2p is part of most Ethereum clients. Implementations include:
 
 WireShark dissectors are available here: https://github.com/ConsenSys/ethereum-dissectors
 
-[Node Discovery Protocol]: ./discv4.md
+[Node Discovery Protocol v4]: ./discv4.md
+[Node Discovery Protocol v5]: ./discv5/discv5.md
 [RLPx transport protocol]: ./rlpx.md
 [Ethereum Wire Protocol]: ./caps/eth.md
 [Light Ethereum Subprotocol]: ./caps/les.md

--- a/discv5/discv5-rationale.md
+++ b/discv5/discv5-rationale.md
@@ -1,4 +1,5 @@
-# Discovery v5 Requirements
+Node Discovery Protocol v5 - Rationale
+======================================
 
 **Draft of January 2019**
 

--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -1,16 +1,96 @@
-# Topic Advertisement in Discovery v5
+Node Discovery Protocol v5 - Theory
+===================================
+
+**Draft of April 2019**
 
 Note that this specification is a work in progress and may change incompatibly without
 prior notice.
 
-The Topic Advertisement system is a part of Node Discovery v5. A node's provided services
-are identified by arbitrary strings called *topics*. Depending on the needs of the
-application, a node can advertise multiple topics or no topics at all. Every node
-participating in the discovery DHT acts as an advertisement medium, meaning that it
-accepts topic registrations from advertising nodes and later returns them to nodes
-searching for the same topic.
+Nodes, Records and Distances
+----------------------------
 
-## Motivation
+A participant in the Node Discovery Protocol is represented by a 'node record' as defined
+in [EIP-778]. The node record keeps arbitrary information about the node. For the purposes
+of this protocol, the node must at least provide an IP address and a UDP port in order to
+participate.
+
+Node records are signed according to an 'identity scheme'. Any scheme can be used with
+Node Discovery Protocol, and nodes using different schemes can communicate.
+
+The identity scheme of a node record defines how a 32-byte 'node ID' is derived from the
+information contained in the record. The 'distance' between two node IDs is the bitwise
+XOR of the IDs, taken as the number.
+
+    distance(n₁, n₂) = n₁ XOR n₂
+
+In many situations, the logarithmic distance (i.e. length of common prefix in bits) is
+used in place of the actual distance.
+
+    logdistance(n₁, n₂) = log2(distance(n₁, n₂))
+
+### Maintaining the local record
+
+Participants should update their record, increase the sequence number and sign a new
+version of the record whenever their information changes. This especially important for
+changes to the node's IP address and port. To detect changes in endpoint, the mirrored IP
+and port found in the [PONG] message can be used to predict whether the local IP address
+has changed.
+
+Node Table
+----------
+
+Nodes in the keep information about other nodes in their neighborhood. Neighbor nodes are
+stored in a routing table consisting of 'k-buckets'. For each `0 ≤ i < 256`, every node
+keeps a k-bucket for nodes of distance between <code>2<sup>i</sup></code> and
+<code>2<sup>i+1<sup></code> from itself.
+
+The Node Discovery Protocol uses `k = 16`, i.e. every k-bucket contains up to 16 node
+entries. The entries are sorted by time last seen — least-recently seen node at the head,
+most-recently seen at the tail.
+
+Whenever a new node N₁ is encountered, it can be inserted into the corresponding bucket.
+If the bucket contains less than `k` entries N₁ can simply be added as the first entry. If
+the bucket already contains `k` entries, the liveness of the least recently seen node in
+the bucket, N₂, needs to be revalidated. If no reply is received from N₂ it is considered
+dead, removed and N₁ added to the front of the bucket.
+
+### Liveness Checks In Practice
+
+Checking node liveness whenever a node is to be added to a bucket is impractical and
+creates a DoS vector. Implementations can perform liveness checks asynchronously with
+bucket addition and occasionally verify that a random node in a random bucket is live.
+
+### Recursive Lookup
+
+A 'lookup' locates the `k` closest nodes to a node ID.
+
+The lookup initiator starts by picking `α` closest nodes to the target it knows of. The
+initiator then sends concurrent [FINDNODE] packets to those nodes. `α` is an
+implementation-defined concurrency parameter, typically `3`. In the recursive step, the
+initiator resends FINDNODE to nodes it has learned about from previous queries. Of the `k`
+nodes the initiator has heard of closest to the target, it picks `α` that it has not yet
+queried and sends FINDNODE to them. Nodes that fail to respond quickly are removed from
+consideration until and unless they do respond.
+
+If a round of FINDNODE queries fails to return a node any closer than the closest already
+seen, the initiator resends the find node to all of the `k` closest nodes it has not
+already queried. The lookup terminates when the initiator has queried and gotten responses
+from the `k` closest nodes it has seen.
+
+### Bucket Maintenance
+
+Nodes are expected to keep track of their close neighbors and regularly refresh their
+information. To do so, a lookup targeting the least recently refreshed bucket should be
+performed at regular intervals.
+
+Topic Advertisement
+-------------------
+
+A node's provided services are identified by arbitrary strings called *topics*. Depending
+on the needs of the application, a node can advertise multiple topics or no topics at all.
+Every node participating in the discovery DHT acts as an advertisement medium, meaning
+that it accepts topic registrations from advertising nodes and later returns them to nodes
+searching for the same topic.
 
 The reason topic discovery is proposed in addition to application-specific networks is to
 solve bootstrapping issues and improve downward scalability of subnetworks. Scalable
@@ -23,9 +103,7 @@ find useful and honest peers, it makes complete isolation a lot harder because i
 prevent the nodes of a small subnet from finding each other, the entire discovery network
 would have to be overpowered.
 
-## Specification
-
-### Topic Advertisement Storage
+### Advertisement Storage
 
 Each node participating in the protocol stores ads for any number of topics and a limited
 number of ads for each topic. The list of ads for a particular topic is called the *topic
@@ -63,14 +141,27 @@ Let us assume that node `A` advertises itself under topic `T`. It selects node `
 advertisement medium and wants to register an ad, so that when node `B` (who is searching
 for topic `T`) asks `C`, `C` can return the registration entry of `A` to `B`.
 
-Node `A` first tells `C` that it wishes to register by requesting a ticket for topic `T`.
+Node `A` first tells `C` that it wishes to register by requesting a ticket for topic `T`,
+using the [REQTICKET] message.
+
+    A -> C  REQTICKET
+
 `C` replies with a ticket. The ticket contains the node identifier of `A`, the topic, a
 serial number and wait period assigned by `C`.
+
+    A <- C  TICKET
 
 Node `A` now waits for the duration of the wait period. When the wait is over, `A` sends a
 registration request including the ticket. `C` does not need to remember its issued
 tickets, just the serial number of the latest ticket accepted from `A` (after which it
 will not accept any tickets issued earlier).
+
+    A -> C  REGTOPIC
+
+If the ticket was valid, Node `C` places `A` into the topic queue for `T`. The
+[REGCONFIRMATION] response message signals whether `A` is registered.
+
+    A <- C  REGCONFIRMATION
 
 ### Ad Placement And Topic Radius Detection
 
@@ -119,8 +210,6 @@ To find nodes, the searcher generates random node IDs inside the topic radius an
 recursive Kademlia lookups on them. All (intermediate) nodes encountered during lookup are
 asked for topic queue enties using the [TOPICQUERY] packet.
 
-# Rationale
-
 Topic search is not meant to be the only mechanism used for selecting peers. A persistent
 database of useful peers is also recommended, where the meaning of "useful" is
 protocol-specific. Like any DHT algorithm, topic advertisement is based on the law of
@@ -130,9 +219,9 @@ disrupting operation, removing incentives to waste resources on trying to do so.
 protocol-level recommendation-based trust system can be useful, the protocol may even have
 its own network topology.
 
-## Security considerations
+### Security considerations
 
-### Spamming with useless registrations
+#### Spamming with useless registrations
 
 Our model is based on the following assumptions:
 
@@ -157,7 +246,7 @@ increase proportionally both with increased honest registration and search effor
 both are increased in response to an attack, the required factor of increased efforts from
 honest actors is proportional to the square root of the attacker's efforts.
 
-### Detecting a useless registration attack
+#### Detecting a useless registration attack
 
 In the case of a symmetrical protocol (where nodes are both searching and advertising
 under the same topic) it is easy to detect when most of the queried registrations turn out
@@ -169,12 +258,14 @@ for servers to also act as clients just to test the server capabilities of other
 advertisers. It is also possible to implement a feedback system between trusted clients
 and servers.
 
-### Amplifying network traffic by returning fake registrations
+#### Amplifying network traffic by returning fake registrations
 
-An attacker might wish to direct discovery traffic to a chosen address. This is prevented
-by not returning endpoint details in the [TOPICNODES] message.
+An attacker might wish to direct discovery traffic to a chosen address by returning
+records pointing to that address.
 
-### Not registering/returning valid registrations
+**TBD: this is not solved**
+
+#### Not registering/returning valid registrations
 
 Although the limited registration frequency ensures that the resource requirements of
 acting as a proper advertisement medium are sufficiently low, such selfish behavior is
@@ -185,5 +276,13 @@ registrations are not returned so it is probably possible to implement a mechani
 out selfish nodes if necessary, but the design of such a mechanism is outside the scope of
 this document.
 
-[TOPICQUERY]: ./discv5-wire.md#TOPICQUERY
-[TOPICNODES]: ./discv5-wire.md#TOPICNODES
+[EIP-778]: https://eips.ethereum.org/EIPS/eip-778
+[PING]: ./discv5-wire.md#ping-request-0x01
+[PONG]: ./discv5-wire.md#pong-response-0x02
+[FINDNODE]: ./discv5-wire.md#findnode-request-0x03
+[NODES]: ./discv5-wire.md#nodes-response-0x04
+[REQTICKET]: ./discv5-wire#reqticket-request-0x05
+[TICKET]: ./discv5-wire#ticket-response-0x06
+[REGTOPIC]: ./discv5-wire#regtopic-request-0x07
+[REGCONFIRMATION]: ./discv5-wire#regconfirmation-response-0x08
+[TOPICQUERY]: ./discv5-wire.md#topicquery-request-0x09

--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -32,9 +32,8 @@ used in place of the actual distance.
 
 Participants should update their record, increase the sequence number and sign a new
 version of the record whenever their information changes. This especially important for
-changes to the node's IP address and port. To detect changes in endpoint, the mirrored IP
-and port found in the [PONG] message can be used to predict whether the local IP address
-has changed.
+changes to the node's IP address and port. The mirrored UDP enveloper IP and port found in
+the [PONG] message can be used to predict whether the local IP address has changed.
 
 Node Table
 ----------

--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -31,7 +31,7 @@ used in place of the actual distance.
 ### Maintaining the local record
 
 Participants should update their record, increase the sequence number and sign a new
-version of the record whenever their information changes. This especially important for
+version of the record whenever their information changes. This is especially important for
 changes to the node's IP address and port. Implementations should determine the external
 endpoint (the Internet-facing IP address and port on which the node can be reached) and
 include it in their record.

--- a/discv5/discv5.md
+++ b/discv5/discv5.md
@@ -1,0 +1,72 @@
+Node Discovery Protocol v5
+==========================
+
+**Draft of April 2019**
+
+Note that this specification is a work in progress and may change incompatibly without
+prior notice.
+
+Welcome to the Node Discovery Protocol v5 specification!
+
+Node Discovery is a system for finding other participants in a peer-to-peer network. The
+system can be used by any node, for any purpose, at no cost other than running the network
+protocol and storing a limited number of other nodes' records. Any node can be used as the
+an entry point into the network.
+
+The system's design is loosely inspired by the Kademlia DHT, but unlike most DHTs no
+arbitrary keys and values are stored. Instead, the DHT stores and relays 'node records',
+which are signed documents providing information about nodes in the network. Node
+Discovery acts as a database of all live nodes in the network and performs three basic
+functions:
+
+- Sampling the set of all live participants at random: by walking the DHT at random the
+  network can be enumerated.
+- Searching for participants providing a certain service: Node Discovery v5 includes a
+  scalable facility for registering 'topic advertisements'. These advertisements can be
+  queried and nodes advertising a topic found.
+- Authoritative resolution of node records: if a node's ID is known, the most recent
+  version of its record can be retrieved.
+
+Specification Overview
+----------------------
+
+The specification has three parts:
+
+- [discv5-wire.md] defines the wire protocol.
+- [discv5-theory.md] describes the algorithms and data structures.
+- [discv5-rationale.md] **(outdated)** contains a design rationale and communication examples.
+
+Comparison With Other Discovery Mechanisms
+------------------------------------------
+
+Systems such as MDNS/Bonjour allow finding hosts in a local-area network. The Node
+Discovery Protocol is designed to work on the Internet and is most useful for applications
+with a large number of participants spread across the Internet.
+
+Systems using a rendezvous server: these systems are commonly used by desktop applications
+or cloud services to connect participants to each other. While undoubtedly efficient, this
+requires trust in the operator of the rendezvous server and these systems are prone to
+censorship. Compared to a rendezvous server, The Node Discovery Protocol doesn't rely on a
+single operator and places a small amount of trust in every participant. It becomes more
+resistant to censorship as the size of the network increases and participants of multiple
+distinct peer-to-peer networks can share the discovery network to further increase its
+resilience.
+
+The Achilles heel of the Node Discovery Protocol is the process of joining the network:
+while any other node may be used as an entry point, such a node must first be located
+through some other mechanism. Several approaches including scalable listing of initial
+entry points in DNS or discovery of participants in the local network can be used for
+reasonable secure entry into the network.
+
+Comparison With Node Discovery v4
+---------------------------------
+
+- Topic advertisement was added.
+- Arbitrary node metadata can be stored/relayed.
+- The protocol no longer relies on the system clock.
+- Communication is encrypted, protecting topic searches and record lookups against passive
+  observers.
+
+[discv5-wire.md]: ./discv5-wire.md
+[discv5-theory.md]: ./discv5-theory.md
+[discv5-rationale.md]: ./discv5-rationale.md

--- a/discv5/discv5.md
+++ b/discv5/discv5.md
@@ -3,10 +3,10 @@ Node Discovery Protocol v5
 
 **Draft of April 2019**
 
+Welcome to the Node Discovery Protocol v5 specification!
+
 Note that this specification is a work in progress and may change incompatibly without
 prior notice.
-
-Welcome to the Node Discovery Protocol v5 specification!
 
 Node Discovery is a system for finding other participants in a peer-to-peer network. The
 system can be used by any node, for any purpose, at no cost other than running the network
@@ -19,8 +19,8 @@ which are signed documents providing information about nodes in the network. Nod
 Discovery acts as a database of all live nodes in the network and performs three basic
 functions:
 
-- Sampling the set of all live participants at random: by walking the DHT at random the
-  network can be enumerated.
+- Sampling the set of all live participants: by walking the DHT, the network can be
+  enumerated.
 - Searching for participants providing a certain service: Node Discovery v5 includes a
   scalable facility for registering 'topic advertisements'. These advertisements can be
   queried and nodes advertising a topic found.
@@ -63,6 +63,7 @@ Comparison With Node Discovery v4
 
 - Topic advertisement was added.
 - Arbitrary node metadata can be stored/relayed.
+- Node identity crypto is extensible, use of secp256k1 keys isn't strictly required.
 - The protocol no longer relies on the system clock.
 - Communication is encrypted, protecting topic searches and record lookups against passive
   observers.


### PR DESCRIPTION
This is my second pass over the spec after working on the implementation
for a while. Changes include:

- There is now a high-level intro document that ties the specs together.
- The 'topics' document is now 'theory' and contains a description of
  the routing table, lookup etc. in addition to topic advertisement
  content.
- Wire protocol is updated based on feedback from implementation.
  - The new handshake replaces the WHOAREYOU and IAM messages
  - conversation-nonce is removed in favor of a simple request-id
  - NODES replaces NEIGHBORS and TOPICNODES
  - message data lists are now up to date with reality
  - All the 'maybes' and 'proposals' are removed from the spec text.
- The 'requirements' document is now 'rationale' but is otherwise
  unchanged.

Closes #60 