### PR TITLE
discv5: fix definition of random-packet

### DIFF
--- a/discv5/discv5-wire.md
+++ b/discv5/discv5-wire.md
@@ -157,8 +157,9 @@ reverse.
 
 The encoding of the 'random packet', sent if no session keys are available, is:
 
-    random-packet    = tag || random-data
-    random-data      = at least 44 bytes of random data
+    random-packet    = tag || rlp_bytes(token) || random-data
+    random-data      = at least 64 bytes of random data
+    token            = 12 bytes of random data
 
 The WHOAREYOU packet, used during the handshake, is encoded as follows:
 


### PR DESCRIPTION
The random packet is basically a message-packet with garbage content.
This change adds auth-tag to the definition to make them structurally
equivalent.