### PR TITLE
discv5: rationale update, minor spec changes

### DIFF
--- a/discv5/discv5-rationale.md
+++ b/discv5/discv5-rationale.md
@@ -44,7 +44,7 @@ negotiation.
 
 #### 1.1.5 Guard against Kademlia implementation flaws
 
-Discovery v4 trusts other nodes to return neighbours according to an agreed distance
+Discovery v4 trusts other nodes to return neighbors according to an agreed distance
 metric. Mismatches in implementation can make it hard for nodes to join the network, or
 lead to network fragmentation.
 
@@ -72,46 +72,51 @@ analysis systems, e.g. using inter-packet timing is a secondary concern.
 Individual potential vulnerabilities are identified below. These each represent their own
 risk mitigation goal.
 
-#### 1.2.1 Replay neighbours
-
-A FINDNODE response (neighbors), if successfully replayed, would pollute the routing table
-with stale information.
-
-#### 1.2.2 Replay of the handshake
+#### 1.2.1 Replay of the handshake
 
 The handshake, if successfully replayed from an older session, would allow a malicious
 node to occupy a former IP location, or pollute the routing table with old information.
 
-#### 1.2.3 Kademlia redirection
+#### 1.2.2 Replay NODES
+
+A NODES response, if successfully replayed, would pollute the routing table with stale
+information.
+
+#### 1.2.3 Replay PONG
+
+A PONG, if successfully replayed, could convince a node that a node is live and
+participating when it isn't.
+
+#### 1.2.4 Kademlia redirection
 
 A FindNode response contains false endpoint information intended at directing traffic at a
 victim / polluting the routing table. A topic query results in fake endpoint information,
 directing traffic at a victim.
 
-#### 1.2.4 Kademlia redirection + self-propagation
+#### 1.2.5 Kademlia redirection + self-propagation
 
 As 1.2.3 but the responses attempt to replicate the malicious node throughout the routing
 table, to amplify the source of pollution and traffic.
 
-#### 1.2.5 Unsolicited replies
+#### 1.2.6 Unsolicited replies
 
 A malicious node is attempting to spam a node with fake responses to typical requests.
 These messages may be replayed from previous communications, or may be new messages with
 spoofed source endpoints. The aim is to disrupt weak implementations or have their
 information be received as authentic, to pollute the recipient's routing table.
 
-#### 1.2.6 Amplification
+#### 1.2.7 Amplification
 
 Malicious requests of small message size are sent from spoofed source IPs to direct larger
 response messages at the victim.
 
-#### 1.2.7 Kademlia direct validation
+#### 1.2.8 Kademlia direct validation
 
 Direct validation of a newly discovered node can be an attack vector. A malicious node may
 supply false node information with the IP of a victim. Validation traffic is then directed
 at the victim.
 
-#### 1.2.8 Kademlia ID count per address validations
+#### 1.2.9 Kademlia ID count per address validations
 
 There are various attacks facilitated by being able to associate multiple fake (or even
 real) malicious node ids with a single IP endpoint. One mitigation method that is
@@ -120,7 +125,7 @@ associated with an IP address. However, this is an attack vector. A malicious ac
 supply many logical node ids for a single IP address and thus prevent the correct node
 from being able to join the network.
 
-#### 1.2.9 Sybil/Eclipse attacks
+#### 1.2.10 Sybil/Eclipse attacks
 
 These attacks rely on being able to create many real nodes, or spoof many logical node IDs
 for a small number of physical endpoints, to form a large, isolated area of the network

--- a/discv5/discv5-rationale.md
+++ b/discv5/discv5-rationale.md
@@ -408,12 +408,11 @@ this document.
   *S/Kademlia: A Practicable Approach Towards Secure Key-Based Routing.* 2007.\
   <https://telematics.tm.kit.edu/publications/Files/267/SKademlia_2007.pdf>
 
-- Xin Sun, Ruben Torres and Sanjay Rao.
-  *Preventing DDoS Attacks with P2P Systems through Robust Membership Management.* 2007.\
-  <https://engineering.purdue.edu/~isl/TR-EE-07-13.pdf>
+- Xin Sun, Ruben Torres and Sanjay Rao. *Feasiblity of DDoS Attacks with P2P Systems and
+  Prevention through Robust Membership Management.* 2007.\
+  <https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1357&context=ecetr>
 
-- Erik Hjelmvik, Wolfgang John.
-  *Breaking and Improving Protocol Obfuscation.* 2010.\
+- Erik Hjelmvik, Wolfgang John. *Breaking and Improving Protocol Obfuscation.* 2010.\
   <https://internetstiftelsen.se/docs/hjelmvik_breaking.pdf>
 
 - Adam Langley, Wan-Teh Chang. *QUIC Crypto*. 2016.\

--- a/discv5/discv5-rationale.md
+++ b/discv5/discv5-rationale.md
@@ -1,49 +1,40 @@
 # Node Discovery Protocol v5 - Rationale
 
-**Draft of January 2019**
+**Draft of August 2019**
 
 Note that this specification is a work in progress and may change incompatibly without
 prior notice.
 
-This document attempts to list the different requirements and security needs on the
-discovery mechanisms and relate these through a design rationale to a new wire protocol
-description.
+This document explains the design requirements and security needs of Discovery v5. In
+addition, the document tries to gather the various vulnerabilities and threats that
+pertain to Kademlia-like p2p networks. Our aim is to make it plain which issues are
+addressed and how they are mitigated, so that the design of the [wire protocol] may be
+verified.
 
-In addition, this document tries to gather the various vulnerabilities and threats that
-pertain to Kademlia-like p2p networks into a set of security requirements. One aim is to
-make it plain which vulnerabilities are addressed and how they are mitigated, so that and
-its completeness may be verified.
-
-The document is structured as the list of requirements, followed by example protocol
-conversation/scenarios that highlight the requirements they address, defining protocol
-spec requirements and implementation recommendations separately. The separation is done
-because some aspects (such as optional features enabled by a runtime configuration flag)
-can't be mandated by the protocol spec.
-
-There is also a placeholder to include notes on what uncertainties could be further
-clarified using simulations. This could be used to help drive simulation development. (It
-would be of real benefit if a reliable network simulation existed, to be maintained along
-with the protocols, to help find weaknesses or answer any other questions about planned or
-current network behavior.)
-
-# Requirements
+# Design Requirements
 
 ## Basic Goals
 
-#### 1.1.1 Replacing V4 Endpoint Proof
+#### 1.1.1 Replace the Discovery v4 Endpoint Proof
 
-The existing mutual endpoint verification process is difficult to reliably implement.
+The existing mutual endpoint verification process is unreliable because either side may
+forget about a previously performed endpoint proof. If node A assumes that node B already
+knows about a recent PING/PONG interaction and sends FINDNODE, the request may fail.
+Implementations of Discovery v4 may guard against this flaw using retries, but retrying is
+really slow and usually not done.
 
-#### 1.1.2 Improve message verification
+#### 1.1.2 Require knowledge of destination node ID for communication
 
-Make it expensive to obtain the logical node ID from discovery communications. Right now
-an unknown UDP sender can provoke responses knowing IP alone, and obtain information about
-the node without knowing the destination node ID.
+Make it expensive to obtain the logical node ID from discovery communications. In
+Discovery v4, any node can provoke responses knowing IP alone, and obtain information
+about a node without knowing its ID. This encourages sloppy implementations to not perform
+proper validation of FINDNODE results and increases the risk of DHT misuse for DDoS
+purposes.
 
-#### 1.1.3 Support mixed ID types
+#### 1.1.3 Support more than one node ID cryptosystem
 
-Ensure the design offers the flexibility required by ENR forward compatibility proposals.
-These will allow identity cryptosystems other than *secp256k1/keccak256*.
+Ensure the DHT can accomodate ENR's with multiple identity systems. This will allow
+identity cryptosystems other than *secp256k1/keccak256*.
 
 #### 1.1.4 Replace node information tuples with ENRs
 
@@ -51,11 +42,11 @@ ENRs include discovery information and more. These signed, versioned records ful
 multiple requirements, such as permitting capability advertisement and transport
 negotiation.
 
-#### 1.1.5 Strengthen Kademlia node compatibility
+#### 1.1.5 Guard against Kademlia implementation flaws
 
-Discovery v4 'trusts' other nodes to return neighbours according to an agreed distance
-metric. Mismatches can make it hard for nodes to join the network, or lead to network
-fragmentation.
+Discovery v4 trusts other nodes to return neighbours according to an agreed distance
+metric. Mismatches in implementation can make it hard for nodes to join the network, or
+lead to network fragmentation.
 
 #### 1.1.6 Secondary topic-based node index
 
@@ -65,15 +56,16 @@ ID.
 
 #### 1.1.7 Change replay prevention
 
-Timestamps as a replay prevention mechanism have led to problems with time
-synchronisation. This must be replaced with a mechanism independent of the clock.
+The use of timestamps as a replay prevention mechanism in Discovery v4 has led to many
+complaints about connectivity when the host's clock was wrong. The protocol should be
+independent of the clock.
 
 #### 1.1.8 Message obfuscation
 
-The protocol must offer a basic type of message obfuscation preventing accidental packet
-mangling or trivial sniffing. The protocol must support extensibility with new obfuscation
-algorithms. It must also avoid inclusion of obvious markers to allow for future DPI
-evasion capabilities.
+The protocol should obfuscate traffic to prevent accidental packet mangling or trivial
+sniffing. It must also avoid inclusion of obvious markers to prevent naive blocking of
+discovery traffic using hard-coded packet signatures. Defense against advanced traffic
+analysis systems, e.g. using inter-packet timing is a secondary concern.
 
 ## Security Goals
 
@@ -82,14 +74,13 @@ risk mitigation goal.
 
 #### 1.2.1 Replay neighbours
 
-A FindNode response (neighbours), if successfully replayed, would pollute the routing
-table with stale information.
+A FINDNODE response (neighbors), if successfully replayed, would pollute the routing table
+with stale information.
 
-#### 1.2.2 Replay "I Am"
+#### 1.2.2 Replay of the handshake
 
-A 'Who Are You?' response, if successfully replayed from an older session, would allow a
-malicious node to occupy a former IP location, or pollute the routing table with old
-information.
+The handshake, if successfully replayed from an older session, would allow a malicious
+node to occupy a former IP location, or pollute the routing table with old information.
 
 #### 1.2.3 Kademlia redirection
 
@@ -141,424 +132,300 @@ from the network.
 
 There are several considerations regarding the coexistence of v4 and v5 network members.
 
-#### 1.3.1 Transition period network formation
+#### 1.3.1 Transition period during network formation
 
-Discovery v4 clients should serve as discovery v5 bootstrap nodes the number of new
-discovery v5 clients is still low.
+Discovery v4 clients should be able to serve as discovery v5 bootstrap nodes while the
+number of new discovery v5 clients is still low.
 
-#### 1.3.2 Avoid circumvention of 1.1.2
+#### 1.3.2 Circumvention of 1.1.2 with v4 PING
 
 While a client supports both the old v4 and newer versions, it is possible for malicious
 actors to pose as a v4 node and recover node IDs from arbitrary IP addresses. This should
 somehow be avoided.
 
-#### 1.3.3 Support unobfuscated messages
-
-Plain messages from v4 nodes should be handled as normal when the recipient node opts in
-to support v4 peers. Obfuscated messages should be formed in such a way that they are
-silently ignored by v4 recipient nodes, without affecting the reputation of the sender.
-
-#### 1.3.4 Open up support for other transports
-
-In the future, nodes should be able to use other transports than UDP.
-
-# Scenarios
-
-## Node Joining Network (Kademlia bootstrap)
-
-In this scenario, node `A` joins the network using node `B` as a 'bootstrap node'.
-
-1. **Node `A` gets initial ENR**
-
-    The initial ENR may be a predefined bootnode, known peer (from previous connections),
-    manually added peer, or manually specified bootnode. ‘Initial ENR’ means the id of the
-    node that first leads to node `A` joining the network.
-    The initial node must be also available from the command line (eg: --bootnodes) or via
-    RPC. If there are already α nodes available, then all of those may be considered
-    initial nodes and run concurrently. ENRs are signed by the issuer. So, to support
-    command line or RPC addition of ENR records, those APIs or user interfaces may need
-    extension to accept an ENR. (Helps **mitigate 1.2.3** by making it harder to add fake
-    data into a client routing table.)
-
-2. **Node `A` begins bootstrap process**
-
-    Calculate the distance, `d`, between node `A`’s ID and the node `B`'s ID.
-
-3. **Node `A` calls findnode on node `B`**
-
-    Request nodes from the bucket covering distance `d`.
-
-    **Addresses 1.1.5.**
-
-4. **Node `B` starts handshake because node `A` is unknown caller**
-
-    At this point there is no message that can be sent back to the caller, such as WhoAreYou
-    as part of a verification process. All messages are signed. This would reveal to the
-    caller the node’s public key based on IP address alone. So, FindNode must also accept
-    the node ID of the recipient (bootnode in this case) as a parameter.
-
-    Bootnode verifies that the intended recipient node ID is itself.
-
-    **Addresses 1.1.2**
-
-5. **Node `B` calls `WhoAreYou` on Node `A`**
-
-    Bootnode responds with a `WhoAreYou` to verify the caller node. The IP address is taken
-    from the packet; there is no source information in the message. The message must be
-    small to prevent amplification: **Mitigates 1.2.6**
-
-    For the same reasons as with FindNode, the WhoAreYou message must accept the intended
-    recipient **(1.1.2)**. The node id is recovered from the message signature and used to
-    call WhoAreYou.
-
-6. **Node `A` replies with `IAm`**
-
-    Node `A` verifies that the intended recipient is itself. It then recovers the node
-    ID from the WhoAreYou request and verifies that it is already known and that the
-    response endpoint is correct. (**Mitigates 1.2.6**)
-
-    Node `A` retrieves its own signed ENR describing itself and sends it as an “I am”
-    response.
-
-7. **Node `B` verifies record of Node `A`**
-
-    The ENR node ID is checked against the recovered IDs. However, there is no guarantee
-    that the IP address contained in the ENR matches that of the UDP frame. There are
-    networking scenarios where NAT supplies one ephemeral endpoint while that member is
-    listening on another.
-
-    Verification of the source data in the ENR must **mitigate 1.2.7** and **1.2.8**.
-    Further, the verification must take into consideration that nodes may have moved from
-    one IP address to another, and that some IP addresses will have clients with new node
-    ids, legitimately. The solution proposed here is to limit the number of node IDs per
-    endpoint per learned-from source.
-
-8. **Node `B` adds ENR to routing table**
-
-    At this point, the ENR is entered into the routing table. The ENR is considered
-    validated and Node `A` has joined node `B`’s table if it has space available.
-
-9. **Node `B` sends `Neighbors` response to Node `A`**
-
-    node `B` now considers the original request (1) a valid request and Node `A` is
-    sent a Neighbors response, which contains the ENRs belonging to the requested bucket.
-
-10. **Node `A` verifies `Neighbors` response**
-
-    Verification of the source data in the ENR must **mitigate 1.2.7** and **1.2.8** (see
-    implementation requirements below).
-
-    N.B.: At this point the returned nodes are added into the table and become candidates
-    for eviction (see ‘aliveness checks’), or may be evicted if chosen as a member of
-    α below.
-
-11. **Repeat process on closest nodes**
-
-    α of the closest nodes to the desired target (self in this case) are selected and the
-    process repeated with concurrent `FindNode` calls to those members.
-
-### Protocol Requirements
-
-- `FindNode` should accept a specific bucket as the parameter to avoid revealing the lookup
-  target.
-- `FindNode` should accept the recipient's ID as a parameter to address requirement 1.1.2.
-- `WhoAreYou` messages should not be much larger, if at all, than the `FindNode` message,
-  to prevent amplification attempts.
-- `WhoAreYou` should also include the recipient's own IDD as a parameter.
-
-### Implementation Requirements
-
-- A `FindNode` call that is followed by a `WhoAreYou` should be implemented as a single
-  conversation, not as concurrent request-replies. This is because a 'standalone'
-  `WhoAreYou` responds with a fairly large `IAm` message, opening opportunities for
-  amplification attacks.
-- Other methods of inserting node information into the routing table using *enode* IDs
-  might not be adequate. Information about if the node is v4 or v5 will be missing, while
-  it will be trivial to populate the routing table with invalid information.
-- If `FindNode` is received with an invalid intended destination *node ID,* these should
-  be ignored without response to avoid revealing any information about the recipient, but
-  repeated occurrences of such messages could indicate the caller is the victim of having
-  its routing table polluted. In future, this information could be perhaps used to trace
-  the source.
-
-## Malicious Node in Lookup Process
-
-Continuing from the above, node `A` contacts the found node `M` which is malicious.
-
-1. **Node `A` calls `FindNode` on `M`**
-
-   Request nodes from the bucket covering distance `d`.
-
-2. **Node `M` responds with `Neighbors`**
-
-   An important observation is that because of the wide bit range of node IDs, most IDs
-   are distant from each other. In other words, most nodes will be found in the top few
-   k-buckets of each other. `FindNode` calls will most likely request the contents in the
-   top 6 or 7 buckets, the overwhelming majority being for top bit. Because of this, it is
-   fairly easy for a malicious actor to generate EC key pairs at random, whose hash (the
-   Kademlia id) will be in those ranges. This means that a malicious actor will have no
-   trouble generating many fake ENRs, correctly signed and placed in the correct k-bucket,
-   bypassing k-bucket verification.
-
-   What is much harder to do is control very many physical IP addresses. At this point,
-   the malicious node can attempt several attacks:
-
-   - Return many fake, signed ENRs, all or mostly pointing to this malicious node’s IP
-     endpoint, in the hope of eclipsing the caller.
-   - Return many fake, signed ENRs, with random IP addresses, in the hope of polluting the table.
-   - Return many fake, signed ENRs, with many IP DDoS targets
-   - Return many fake, signed ENRs, with IP addresses pointing at a DDoS victim.
-
-3. **Node `A` verifies `Neighbors` response**
-
-   As described in the previous section, most `FindNode`-based attacks will be based on
-   responding with made-up node information. A certain factor must be decided for the
-   system, which limits the number of logical node IDs for a physical endpoint address
-   learned from a specific source.
-
-   - If too few IPs are used in the response, the malicious node’s responses will fail the
-     check, responses will be ignored, and node `M` evicted from the table.
-   - If IPs in the response are non-existent, some of the nodes will become rejected in
-     the following FindNode call, while ‘aliveness checks’ will evict the remainder.
-
-### Implementation Recommendations
-
-- A factor must be decided (as described above) that limits number of logical node IDs
-  for a physical endpoint address learned from a specific source. \*\** It must balance
-  serving as a deterrent while permitting multiple legitimate nodes behind NAT.
-- The table must maintain a learned-from property per ENR. ENRs may be learned from
-  multiple sources.
-- If many nodes returned by node `M` fail subsequent FindNode attempts (selections from
-  that list may be applied to multiple iterations of the lookup process), then the learned-from
-  property will be used to remove all entries originating from that source and evict that
-  learned-from node from the table.
-- ENRs may be rediscovered from different sources, so implementations should strive to
-  maintain a blacklist of evicted malicious nodes.
-- If the malicious actor is attempting to pollute the DHT with junk, then node `A` is at
-  risk of *receiving a FindNode request from a 3^rd^ bona-fide node* and redistributing
-  the junk nodes to the bona-fide node, causing **eventual loss of reputation for node `A`
-  and possible network expulsion**. The plus though is that there is strong incentive for
-  nodes to validate `Neighbors` responses. However, because of vulnerability 1.2.7 and DoS
-  attack risks direct validations should be avoided. Some studies (eg: [this
-  one](https://engineering.purdue.edu/~isl/TR-EE-07-13.pdf)) recommend combining methods
-  to validate the nodes. These strategies may include:
-
-  - Exclude unvalidated nodes from Neighbors responses and defer validation until the
-    protocol 'naturally' confirms them through `Ping` and `FindNode` calls.
-  - Wait for multiple corroborations of the node, for some number of matching ENRs
-    returned from multiple sources, weighting the factor to balance between faster
-    propagation times and an increased likelihood of `Ping`/`FindNode` confirmation.
-  - Schedule direct validation of all new ENRs over a longer period to avoid DDoS of
-    multiple targets, while omitting unvalidated nodes from `Neighbor` responses.
-  - A combination of the above.
-
-> The approach should most likely involve avoiding redistribution of
-> unvalidated nodes, but simulation would benefit here \*\*
-
-## Aliveness Checks
-
-The discovery protocol should periodically ping nodes or call `FindNode` to refresh
-buckets and check for aliveness. These checks ensure that members of the node table are
-responsive.
-
-### Protocol Requirements
-
-- `Ping` packet format must inclue the destination node ID to allow distinguishing
-  between offline nodes and nodes which j
-
-### Implementation Notes / Requirements
-
-- `Pong` will only be sent if the incoming Ping matches the recipient's *node ID.*
-  **Addresses 1.1.2**
-
-- Ping failure (pong timeout) must cause a loss of ENR learned-from reputation and
-  eventual expulsion, and deletion of the Ping target (and potentially all records from
-  the same source) from the table.
-
-## v4 Node Attempts Bonding Process on v5 Node
-
-If a v5 Node can respond with a signed v4 Pong to a v4 Ping, then no mitigation of
-**1.1.2** is available. However, if the v5 Node rejects v4 Pings, then the *Bonding*
-process will fail and new v5 Nodes will not be able to join the network. **Partially
-addresses 1.3.**
-
-#### Implementation Recommendations
-
-Implementations of v5 should continue to support v4 by default.
-
-## v4/v5 Interoperability
-
-Discovery v4 and v5 are distinct networks. However, since both systems support ENR,
-records from v4 can be relayed in v5. The v4 network can also be used as a bootstrapping
-system for v5. In the following scenario, a v5 node (`A`) joins the network using a v4
-node (`B`) which supports [EIP-868].
-
-1. **`A` sends v4 ping to `B`**
-
-    This is needed to start the v4 endpoint proof procedure. `A`s ping should
-    include its current ENR sequence number.
-
-2. **`B` sends v4 pong and pings back**
-
-    The pong indicates support for EIP-868 by listing `B`s ENR sequence number.
-
-3. **`A` sends v4 pong to `B`**
-
-    This completes the v4 endpoint proof.
-
-4. **`A` requests `B`s ENR using the EIP-868 enrRequest message**
-
-5. **`B` responds with ENR**
-
-    The ENR sent by `B` is authenticated against `B`s node key. Support for discovery v5 is
-    announced through a key/value pair in the record.
-
-6. **`A` calls v5 `FindNode` on `B`**
-
-    This is possible because `A` now knows that `B` understands v5.
-
-### Protocol Requirements
-
-- ENRs exchanged must include a key/value pair describing the supported protocol version.
-- The v5 packet format must be recognizable and must not match the v4 format.
-
-### Implementation Recommendations
-
-- Implementations must be able to run both v4 and v5 on the same port and be able to
-  distinguish packets of both protocol versions.
-
-**Partially addresses 1.3.**
-
-## Obfuscation
-
-The above points explain that nodes should implement both v4 and newer versions of
-Discovery, using indicators from either the stored ENR or packet format to determine which
-protocol type to use.
-
-While v5 nodes permit it, incoming messages that are not obfuscated should be readable and
-should generate plain responses.
-
-Accidental attempts at calling `FindNode` or sending other v5 messages to a v4 client
-should not cause any loss of network reputation but should cause v4 nodes to silently fail
-when the message is received. Forward compatibility should be in place to allow for
-modifications to the obfuscation method.
-
-### Protocol Requirements
-
-- The wire format should handle plain (unobfuscated) messages.
-- The incoming obfuscation type (plain, or otherwise..) determines the obfuscation
-  response type. This allows for per-session or per-RPC modification of the obfuscation
-  type.
-- Forward compatibility may allow for multiple obfuscation types:
-  - XOR with some value
-  - Pad Packets
-  - Random Truncation
-  - Other algorithms targeted at DPI
-- Header (hash and message signature) need not be obfuscated as the data is near random.
-- Any parameters to the obfuscation algorithm are known/supplied as part of the
-  transmission.
-
-### Implementation Notes / Requirements
-
-- ENR descriptors should indicate that the node is v4 and requires a plain message.
-- In future, to confuse DPIs, one obfuscation type may be "ignore the next N packets,
-  which will have random packet-types" to change the entropy of the packet-type byte.
-- A runtime configuration option indicating whether unexposed traffic is supported may be
-  added.
-
-**Addresses 1.1.8.**
-
-## Packet Replay
-
-The expiration field used to detect replay attempts has been a source of difficulty
-because nodes are often slightly out of time synchronization. The replacement mechanism
-proposed involves the use of a 'conversation nonce'. Conversation Nonce is explained in
-the [wire protocol specification].
-
-Generally, replay scenarios are where a malicious actor attempts to disrupt a conversation
-or pollute the routing tables by replaying messages obtained from eavesdropping older
-communications. For example, if a `Neighbors` message containing old information is
-successfully replayed back to a `FindNode` requester, at best the requester's routing
-table would be polluted, at worst the intended recipient of the `FindNode` request could
-lose reputation. A similar scenario applies for `WhoAreYou` / `IAm`.
-
-**TBD: add scenario where replayed FindNode is rejected.**
-
-#### Protocol Requirements
-
-- The conversation nonce is used throughout a conversation, which is an exchange of
-  messages between nodes. A simple request-reply call is also a conversation.
-- The initiator of a conversation supplies the conversation nonce as part of the message,
-  which is used in the reply or in any potential future more complex conversations.
-
-**Mitigates 1.2.1 and 1.2.2.**
-
-### Topic Advertisement Request
-
-The topic discovery proposal involves registering advertisements that nodes support
-certain abstract 'topics,' and offers a mechanism for discovering nodes via those
-advertisements. New packets must be added to support registering for a topic and querying
-the topic table.
-
-#### Protocol Requirements
-
-- All the new request packets must include the target node ID and the conversation nonce
-  in order to **mitigate 1.2.1 and address 1.1.2**
-
-- TopicQuery need not return node IDs.
-  - It is possible to direct the subsequent lookup to malicious endpoints or generally
-    produce a lot of lookup traffic that never converges.
-  - TopicQuery returning *node IDs* places a requirement on the `FindNode` process that
-    it must converge on the *ID*. This is not guaranteed until simulations confirm that
-    the new `FindNode` variant does indeed behave reliably. \*\*
-  - Proposals elsewhere in this document describe that discovered ENRs should be
-    restricted according to a count of logical ids per IP per learned-from source. These
-    mitigations ensure that TopicQuery can return ENRs directly, so long as those are
-    validated according to the same criteria.
-- The request-reply calls here all return large packets. To avoid amplification the
-  calling node must be known, so the recipient node must initiate a `WhoAreYou` check to
-  the caller (as in `FindNode`). As with `FindNode` the same determination must be made if
-  `WhoAreYou`/`IAm` returns a large enough packet to be an amplification source itself, in
-  which case the `WhoAreYou`/`IAm` check must be considered an integral part of the
-  `TopicQuery`-related conversations using the same conversation nonce.
-- A limit to the number of records in `TopicQuery` should be adopted.
-
-### Implementation Recommendations
-
-- ENRs returned by `TopicQuery` should be validated as though they were discoveries.
-- ENRs returned by `TopicQuery` may be added into the Kademlia routing table.
-
-## Mixing Identity Schemes
-
-The 'id' used in the wire protocol is a 32 byte ID. Currently this is the hash of the
-64-byte secp256k1 identity. This scheme may change, and nodes may even eventually have
-multiple public keys. The ENR will eventually include additional dictionary entries to
-specify the node ID directly and/or how to obtain it from a public key.
-
-**TBD Add scenario containing two nodes with different identity schemes.**
-
-# Simulation Notes Placeholder
-
-Throughout the document wherever the \*\* reference is shown, a note regarding network
-simulation can be found.
-
-These are collated here, where any new simulation requirements can be added.
-
-The aim is that for validation of changes or for a deeper understanding of threats and
-network behaviors, these notes can serve as a set of requirements for development of a
-network simulations.
-
-- Determine factor limiting the number of logical node IDs per IP endpoint per
-  learned-from source.
-- Balance this factor against legitimate NAT scenarios.
-- If a `Neighbours` response includes junk ENRs, work out a balance between validating
-  them and timely redistribution of such information.
-- If `TopicQuery` is to return node IDs rather than ENRs, then verify that the new
-  `FindNode` method allows a look-up process to reliably converge on that node ID.
-- Check network behavior with different message sizes to balance reliability with MTU.
-- Check that topic advertisements don't easily allow scraping of node IDs with their IP
-  endpoints (1.1.2) If they do, work out the best balance for a limit on `TopicQuery`
-  response node list lengths.
-
-[wire protocol specification]: ./discv5-wire.md
-[EIP-868]: https://eips.ethereum.org/EIPS/eip-868
+# Rationale
+
+## Why UDP?
+
+The wire protocol specification mandates the use of UDP. This may seem restrictive, but
+use of UDP communication is an important part of the design. While there is no single
+reason which ultimately dictates this choice, there are many reasons why the system as a
+whole will function a lot better in the context of UDP.
+
+For discovery to work, all nodes must be able to communicate with each other on equal
+footing. The network won't form properly if some nodes can only communicate with certain
+other nodes. Incooperative NAT in between the node and the Internet can cause
+communication failure. UDP is fundamentally easier to work with when it comes to NAT
+traversal. No explicit hole-punching is required if the NAT setup is capable of full-cone
+translation, i.e. a single packet sent to any other node establishes a port mapping which
+allows packets from others to reach the node behind NAT.
+
+Unlike other DHT systems such as IPFS, the node discovery protocol mandates a single wire
+protocol to be implemented by everyone. This avoids communication failures due to
+incompatible transports and strengthens the DHT because all participants are guaranteed to
+be reachable on the declared endpoint. It is also fundamentally simpler to reason about
+and implement: the protocol either works in a certain context or it doesn't. If the
+protocol cannot be used because the networking environment doesn't support UDP, another
+discovery mechanism must be chosen.
+
+Another reason for UDP is communication latency: participants in the discovery protocol
+must be able to communicate with a large number of other nodes within a short time frame
+to establish and maintain the neighbor set and must perform regular liveness checks on
+their neighbors. For the topic advertisement system, registrants collect tickets and must
+use them as soon as the ticket expires to place an ad in a topic queue.
+
+These protocol interactions are difficult to implement in a TCP setting where connections
+require multiple round-trips before application data can be sent and the connection
+lifecycle needs to be maintained. An implementation of the wire protocol on a TCP-based
+transport would either need permanent connection to hundreds of nodes, in which case the
+application would be short on file descriptors, or establish many short-lived TCP
+connections per second to communicate with specific nodes.
+
+Yet another useful property of UDP is that packets aren't required to reach their
+destination --- intermediaries may drop arbitrary packets. This strengthens the protocol
+because it must be designed to function even under bad connectivity. Implementations may
+exploit the possibility of packet loss to their advantage. A participant can never tell
+whether a certain request wasn't answered in time because the recipient chose to ignore it
+or because their own connection isn't working. An implementation that tries to minimize
+traffic or CPU overhead could simply drop a certain amount of packets at application level
+to stay within self-imposed limits.
+
+## Why Kademlia?
+
+Kademlia is a simple distributed hash table design proposed in 2002. It is commonly used
+for file-sharing systems where content is stored by hash and distributed among
+participants based on their 'proximity' according to the XOR distance metric.
+
+Node discovery is a Kademlia-inspired system but doesn't store any files, only node
+information is relayed. We chose Kademlia primarily because the algorithm is simple and
+understandable while providing a distributed database that scales with the number of
+participants. Our system also relies on the routing table to allow enumeration and random
+traversal of the whole network, i.e. all participants can be found. Most importantly,
+having a structured network with routing enables thinking about DHT 'address space' and
+'regions of address space'. These concepts are used to build the [topic-based node index].
+
+Kademlia is often criticized as a naive design with obvious weaknesses. We believe that
+most issues with simple Kademlia can be overcome by careful programming and the benefits
+of a simple design outweigh the cost and risks of maintaining a more complex system.
+
+## Sybil and Eclipse Attacks
+
+The well-known 'sybil attack' is based on the observation that creating node identities is
+essentially free. In any system using a measure of proximity among node identities, an
+adversary may place nodes close to a chosen node by generating suitable identities. For
+basic node discovery through network enumeration, the 'sybil attack' poses no significant
+challenge. Sybils are a serious issue for the topic-based node index, especially for
+topics provided by few participants, because the index relies on node distance.
+
+An 'eclipse attack' is usually based on generating sybil nodes with the goal of polluting
+the victim node's routing table. Once the table is overtaken, the victim has no way to
+find any other nodes but those controlled by the adversary. Even if creating sybil nodes
+were somehow impossible, 'eclipsing' a node might still be achieved through other means
+such as directing large amounts of traffic to the node. When the victim node is unable to
+keep up regular communication with the rest of the network it may lose connection and be
+forced into re-bootstrapping its routing table --- a situation in which it is most
+vulnerable.
+
+Both the 'sybil attack' and the 'eclipse attack' must be considered for any structured
+overlay network, and there is no single optimal solution to fully protect against these
+attacks. However, certain implementation decisions can make them more expensive or render
+them ineffective.
+
+As a general measure, implementations can place IP-based limits on the content of their
+routing table. For example, limiting Kademlia table buckets to two nodes from every /24 IP
+subnetwork and the whole table to 10 nodes per /24 IP subnetwork significantly increases
+the number of hosts an attacker must control to overtake the routing table. Such limits
+are effective because IPv4 addresses are a scarce resource. Subnetwork-based limits remain
+effective even as IPv6 adoption progresses.
+
+To counter being eclipsed via repeated contact by an adversary, implementations of the
+Kademlia table should avoid taking on new members on incoming contact unless the table is
+well-stocked from outbound queries. Readers of the original Kademlia paper may easily
+assume that liveness checks on bucket members should be performed just when a new node
+tries to enter the bucket, but doing so increases the risk of emptying the table through
+DoS. We therefore recommend to perform liveness checks on a separate schedule which is
+independent of incoming requests. Checks may also be paused or delayed when the node is
+under high load. The number of past liveness checks performed on a bucket member is an
+important indicator of its age: Implementations should favor long-lived nodes and may
+relax liveness checks according to node age.
+
+A well-researched countermeasure to sybil attacks is to make creation of identities
+computationally expensive. While effective in theory, there are significant downsides to
+this approach. Nodes on resource-constrained devices such as mobile phones may not be able
+to solve the computational puzzle in time to join the network. Continuous advances in
+hashing technology which speed up cryptocurrency proof-of-work algorithms show that this
+way of securing the network requires constant adjustments to thresholds and can never beat
+determined attackers.
+
+Support for mixed ENR identity schemes, described later in this document, allows for an
+escape hatch to introduce arbitrary optional constraints (including proof-of-work) on node
+identities. Thus, while the issue is not directly addressed at wire protocol level, there
+is no inherent blocker for solving it as the need arises.
+
+## Node Records and Their Properties
+
+In Discovery v5, all node information is exchanged using [node records]. Records are
+self-signed by the node they describe and contain arbitrary key-value pairs. They also
+contain a sequence number to determine which copy of the record is newer when multiple
+copies are available. When a node record is changed by its owner, the sequence number
+increases. The new record 'syncs' to neighboring nodes because they will request it during
+liveness revalidation. The record is also 'pushed' on to newly seen nodes as part of the
+handshake.
+
+Signing records prevents any intermediary node from changing the content of a record. Any
+node's information is either available in the exact form it was published or not at all.
+To make the system secure, proper validation of records is important. Implementations must
+verify the signature of all received records. Implementations should also avoid sharing
+records containing no usable IP addresses or ports and check that Internet hosts do not
+attempt to share records containing LAN IP addresses.
+
+## On Encryption
+
+An early draft of Discovery v5 integrated weak obfuscation based on XORing packet content
+as an optional facility. As development of the protocol progressed, we understood that
+traffic amplification, replay and packet authentication could all be solved by introducing
+a real encryption scheme. The way the handshake and encryption works is primarily aimed at
+these issues and is not supposed to ensure complete anonymity of DHT users. While it does
+protect against passive observers, the handshake is not forward-secure and active protocol
+participants can access node information by simply asking for it.
+
+Node identities can use different kinds of keys depending on the identity scheme used in
+the node record. This has implications on the handshake because it deals with the public
+key used to derive the identity. Implementations of Discovery v5 must agree on the set of
+supported identity schemes to keep the network interoperable and custom code to verify the
+handshake is required for every new scheme. We believe this is an acceptable tradeoff
+because introducing a new kind of node identity is a rare event.
+
+Since the handshake performs complex cryptographic operations (ECDH, signature
+verification) performance of the handshake is a big concern. Benchmarking the experimental
+Go implementation shows that the handshake computation takes 500µs on a 2014-era laptop
+using the default secp256k1/keccak256 identity scheme. That's a lot, but note the cost
+amortizes because nodes commonly exchange multiple packets. Subsequent packets in the same
+conversation can be decrypted and authenticated in just 2µs. The most common protocol
+interaction is a FINDNODE or TOPICQUERY request on an unknown node with 4 NODES responses.
+
+To put things into perspective: encryption and authentication in Discovery v5 is still a
+significant improvement over the authentication scheme used in Discovery v4, which
+performs secp256k1 signature 'recovery' (benchmark: ~170µs) on every packet. A FINDNODE
+interaction with an unknown v4 node takes 7 packets (2x PING/PONG, FINDNODE, 2x NEIGHBORS)
+and costs 1.2ms on each side for the crypto alone. In addition, the v5 handshake reduces
+the risk of computational DoS because it costs as much to create as it costs to verify and
+cannot be replayed.
+
+## On Amplification and Replay
+
+Any openly accessible packet-based system must consider misuse of the protocol for traffic
+amplification purposes. There are two possible avenues of attack: In the first, an
+adversary who wishes to attack a third-party host may send packets with 'spoofed' source
+IP address to a node, attempting to make the node send a larger response to the victim
+endpoint. In the second, the adversary attempts to install a node record containing the
+victim's endpoint in the DHT, causing other nodes to direct packets to the victim.
+
+The handshake handles the first kind of attack by responding with a small WHOAREYOU packet
+whenever any request is received from an unknown endpoint. This is safe because the
+adversary's packet is always larger than the WHOAREYOU response, removing the incentive
+for the attack. To make the countermeasure work, implementations must keep session secrets
+not just per node ID, but also per node IP.
+
+The second kind of attack--- installing the victim as a node ---is handled by requiring
+that implementations mustn't answer queries with nodes whose liveness hasn't been
+verified. When a node is added to the Kademlia table, it must pass at least one check on
+the IP declared in the node record before it can be returned in a NODES response.
+
+An adversary may also try to replay previously sent/seen packets to impersonate a node or
+disturb the operation of the protocol. Session keys per node-ID/IP generally prevent
+replay across sessions. The `request-id`, mirrored in response packets, prevents replay of
+responses within a session.
+
+## Security Considerations for the Topic Index
+
+### Spamming with useless registrations
+
+Our model is based on the following assumptions:
+
+- Anyone can place their own advertisements under any topics and the rate of placing
+  registrations is not limited globally. The number of active registrations at any time is
+  roughly proportional to the resources (network bandwidth, mostly) spent on advertising.
+- Honest actors whose purpose is to connect to other honest actors will spend an adequate
+  amount of efforts on registering and searching for registrations, depending on the rate
+  of newly established connections they are targeting. If the given topic is used only by
+  honest actors, a few registrations per minute will be satisfactory, regardless of the
+  size of the subnetwork.
+- Dishonest actors may want to place an excessive amount of registrations just to disrupt
+  the discovery service. This will reduce the effectiveness of honest registration efforts
+  by increasing the topic radius and/or the waiting times. If the attacker(s) can place a
+  comparable amount or more registrations than all honest actors combined then the rate of
+  new (useful) connections established throughout the network will reduce proportionally
+  to the `honest / (dishonest + honest)` registration rates.
+
+This adverse effect can be countered by honest actors increasing their registration and
+search efforts. Fortunately, the rate of established connections between them will
+increase proportionally both with increased honest registration and search efforts. If
+both are increased in response to an attack, the required factor of increased efforts from
+honest actors is proportional to the square root of the attacker's efforts.
+
+### Detecting a useless registration attack
+
+In the case of a symmetrical protocol (where nodes are both searching and advertising
+under the same topic) it is easy to detect when most of the queried registrations turn out
+to be useless and increase both registration and query frequency. It is a bit harder but
+still possible with asymmetrical (client-server) protocols, where only clients can easily
+detect useless registrations, while advertisers (servers) do not have a direct way of
+detecting when they should increase their advertising efforts. One possible solution is
+for servers to also act as clients just to test the server capabilities of other
+advertisers. It is also possible to implement a feedback system between trusted clients
+and servers.
+
+### Amplifying network traffic by returning fake registrations
+
+An attacker might wish to direct discovery traffic to a chosen address by returning
+records pointing to that address.
+
+**TBD: this is not solved.**
+
+### Not registering/returning valid registrations
+
+Although the limited registration frequency ensures that the resource requirements of
+acting as a proper advertisement medium are sufficiently low, such selfish behavior is
+possible, especially if some client implementations choose the easy way and not implement
+it at all. This is not a serious problem as long as the majority of nodes are acting
+properly, which will hopefully be the case. Advertisers can easily detect if their
+registrations are not returned so it is probably possible to implement a mechanism to weed
+out selfish nodes if necessary, but the design of such a mechanism is outside the scope of
+this document.
+
+# References
+
+- Petar Maymounkov and David Mazières.
+  *Kademlia: A Peer-to-peer Information System Based on the XOR Metric.* 2002.\
+  <https://www.scs.stanford.edu/~dm/home/papers/kpos.pdf>
+
+- Atul Singh, Tsuen-Wan “Johnny” Ngan, Peter Druschel, Dan S. Wallach.
+  *Eclipse Attacks on Overlay Networks: Threats and Defenses*. 2006.\
+  <https://www.cs.rice.edu/~druschel/publications/Eclipse-Infocom.pdf>
+
+- Ingmar Baumgart and Sebastian Mies.
+  *S/Kademlia: A Practicable Approach Towards Secure Key-Based Routing.* 2007.\
+  <https://telematics.tm.kit.edu/publications/Files/267/SKademlia_2007.pdf>
+
+- Xin Sun, Ruben Torres and Sanjay Rao.
+  *Preventing DDoS Attacks with P2P Systems through Robust Membership Management.* 2007.\
+  <https://engineering.purdue.edu/~isl/TR-EE-07-13.pdf>
+
+- Erik Hjelmvik, Wolfgang John.
+  *Breaking and Improving Protocol Obfuscation.* 2010.\
+  <https://internetstiftelsen.se/docs/hjelmvik_breaking.pdf>
+
+- Adam Langley, Wan-Teh Chang. *QUIC Crypto*. 2016.\
+  <https://docs.google.com/document/d/1g5nIXAIkN_Y-7XJW5K45IblHd_L2f5LTaDUDwvZ5L6g>
+
+- W3C Credentials Community Group. *Decentralized Identifiers (DIDs) Spec.* 2017.\
+  <https://w3c-ccg.github.io/did-spec>
+
+- Yuval Marcus, Ethan Heilman, Sharon Goldberg.
+  *Low-Resource Eclipse Attacks on Ethereum’s Peer-to-Peer Network.* 2018.\
+  <https://eprint.iacr.org/2018/236.pdf>
+
+[wire protocol]: ./discv5-wire.md
+[topic-based node index]: ./discv5-theory.md#topic-advertisement
+[node records]: https://eips.ethereum.org/EIPS/eip-778

--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -220,63 +220,6 @@ disrupting operation, removing incentives to waste resources on trying to do so.
 protocol-level recommendation-based trust system can be useful, the protocol may even have
 its own network topology.
 
-## Security considerations
-
-### Spamming with useless registrations
-
-Our model is based on the following assumptions:
-
-- Anyone can place their own advertisements under any topics and the rate of placing
-  registrations is not limited globally. The number of active registrations at any time is
-  roughly proportional to the resources (network bandwidth, mostly) spent on advertising.
-- Honest actors whose purpose is to connect to other honest actors will spend an adequate
-  amount of efforts on registering and searching for registrations, depending on the rate
-  of newly established connections they are targeting. If the given topic is used only by
-  honest actors, a few registrations per minute will be satisfactory, regardless of the
-  size of the subnetwork.
-- Dishonest actors (attackers) may want to place an excessive amount of registrations just
-  to disrupt the discovery service. This will reduce the effectiveness of honest
-  registration efforts by increasing the topic radius and/or the waiting times. If the
-  attacker(s) can place a comparable amount or more registrations than all honest actors
-  combined then the rate of new (useful) connections established throughout the network
-  will reduce proportionally to the honest / (dishonest + honest) registration rates.
-
-This adverse effect can be countered by honest actors increasing their registration and
-search efforts. Fortunately, the rate of established connections between them will
-increase proportionally both with increased honest registration and search efforts. If
-both are increased in response to an attack, the required factor of increased efforts from
-honest actors is proportional to the square root of the attacker's efforts.
-
-### Detecting a useless registration attack
-
-In the case of a symmetrical protocol (where nodes are both searching and advertising
-under the same topic) it is easy to detect when most of the queried registrations turn out
-to be useless and increase both registration and query frequency. It is a bit harder but
-still possible with asymmetrical (client-server) protocols, where only clients can easily
-detect useless registrations, while advertisers (servers) do not have a direct way of
-detecting when they should increase their advertising efforts. One possible solution is
-for servers to also act as clients just to test the server capabilities of other
-advertisers. It is also possible to implement a feedback system between trusted clients
-and servers.
-
-### Amplifying network traffic by returning fake registrations
-
-An attacker might wish to direct discovery traffic to a chosen address by returning
-records pointing to that address.
-
-**TBD: this is not solved.**
-
-### Not registering/returning valid registrations
-
-Although the limited registration frequency ensures that the resource requirements of
-acting as a proper advertisement medium are sufficiently low, such selfish behavior is
-possible, especially if some client implementations choose the easy way and not implement
-it at all. This is not a serious problem as long as the majority of nodes are acting
-properly, which will hopefully be the case. Advertisers can easily detect if their
-registrations are not returned so it is probably possible to implement a mechanism to weed
-out selfish nodes if necessary, but the design of such a mechanism is outside the scope of
-this document.
-
 [EIP-778]: https://eips.ethereum.org/EIPS/eip-778
 [PONG]: ./discv5-wire.md#pong-response-0x02
 [FINDNODE]: ./discv5-wire.md#findnode-request-0x03

--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -1,6 +1,6 @@
 # Node Discovery Protocol v5 - Theory
 
-**Draft of April 2019.**
+**Draft of August 2019.**
 
 Note that this specification is a work in progress and may change incompatibly without
 prior notice.
@@ -58,11 +58,20 @@ dead, removed and N₁ added to the front of the bucket.
 Neighbors of very low distance are unlikely to occur in practice. Implementations may omit
 buckets for low distances.
 
-### Liveness Checks In Practice
+### Table Maintenance In Practice
+
+Nodes are expected to keep track of their close neighbors and regularly refresh their
+information. To do so, a lookup targeting the least recently refreshed bucket should be
+performed at regular intervals.
 
 Checking node liveness whenever a node is to be added to a bucket is impractical and
 creates a DoS vector. Implementations can perform liveness checks asynchronously with
-bucket addition and occasionally verify that a random node in a random bucket is live.
+bucket addition and occasionally verify that a random node in a random bucket is live by
+sending [PING]. When the PONG response indicates that a new version of the node record is
+available, the liveness check should pull the new record and update it in the local table.
+
+For FINDNODE, implementations must avoid returning any nodes whose liveness has not been
+verified.
 
 ### Recursive Lookup
 
@@ -80,12 +89,6 @@ If a round of FINDNODE queries fails to return a node any closer than the closes
 seen, the initiator resends the find node to all of the `k` closest nodes it has not
 already queried. The lookup terminates when the initiator has queried and gotten responses
 from the `k` closest nodes it has seen.
-
-### Bucket Maintenance
-
-Nodes are expected to keep track of their close neighbors and regularly refresh their
-information. To do so, a lookup targeting the least recently refreshed bucket should be
-performed at regular intervals.
 
 ## Topic Advertisement
 
@@ -221,6 +224,7 @@ protocol-level recommendation-based trust system can be useful, the protocol may
 its own network topology.
 
 [EIP-778]: https://eips.ethereum.org/EIPS/eip-778
+[PING]: ./discv5-wire.md#ping-request-0x01
 [PONG]: ./discv5-wire.md#pong-response-0x02
 [FINDNODE]: ./discv5-wire.md#findnode-request-0x03
 [REQTICKET]: ./discv5-wire.md#reqticket-request-0x05

--- a/discv5/discv5-wire.md
+++ b/discv5/discv5-wire.md
@@ -175,7 +175,7 @@ header completing the handshake. The plain text of the authentication response i
     version          = 5
     id-nonce-sig     = sign(static-node-key, sha256("discovery-id-nonce" || id-nonce))
     static-node-key  = the private key used for node record identity
-    node-record      = current record of sender
+    node-record      = record of sender OR [] if enr-seq in WHOAREYOU != current seq
 
 `auth-response-pt` is encrypted with a separate key and uses an all-zero nonce. This is
 safe because only one message is ever encrypted with `auth-response-key`.

--- a/discv5/discv5-wire.md
+++ b/discv5/discv5-wire.md
@@ -1,6 +1,6 @@
 # Node Discovery Protocol v5 - Wire Protocol
 
-**Draft of April 2019.**
+**Draft of August 2019.**
 
 This document specifies the wire protocol of Node Discovery v5. Note that this
 specification is a work in progress and may change incompatibly without prior notice.
@@ -143,14 +143,14 @@ new keys.
 
 ### Packet Encoding
 
-All packets start with a fixed-size `tag`. For a packet sent by node A to node B:
+All regular packets except WHOAREYOU start with a fixed-size `tag`. For a packet sent by
+node A to node B:
 
     tag              = xor(sha256(dest-node-id), src-node-id)
     dest-node-id     = 32-byte node ID of B
     src-node-id      = 32-byte node ID of A
 
-The recipient can recover the sender's ID by performing the same calculation in
-reverse.
+The recipient can recover the sender's ID by performing the same calculation in reverse.
 
     src-node-id      = xor(sha256(dest-node-id), tag)
 
@@ -162,25 +162,29 @@ The encoding of the 'random packet', sent if no session keys are available, is:
 
 The WHOAREYOU packet, used during the handshake, is encoded as follows:
 
-    whoareyou-packet = tag || magic || [token, id-nonce, enr-seq]
+    whoareyou-packet = magic || [token, id-nonce, enr-seq]
     magic            = sha256(dest-node-id || "WHOAREYOU")
     token            = auth-tag of request
     id-nonce         = 32 random bytes
     enr-seq          = highest ENR sequence number of node A known on node B's side
 
 The first encrypted message sent in response to WHOAREYOU contains an authentication
-header. Note that the `auth-response` is encrypted with a separate key and uses an
-all-zero nonce. This is safe because only one message is ever encrypted with
-`auth-response-key`.
+header completing the handshake. The plain text of the authentication response is.
+
+    auth-response-pt = [version, id-nonce-sig, node-record]
+    version          = 5
+    id-nonce-sig     = sign(static-node-key, sha256("discovery-id-nonce" || id-nonce))
+    static-node-key  = the private key used for node record identity
+    node-record      = current record of sender
+
+`auth-response-pt` is encrypted with a separate key and uses an all-zero nonce. This is
+safe because only one message is ever encrypted with `auth-response-key`.
 
     message-packet   = tag || auth-header || message
-    auth-header      = [auth-tag, auth-scheme-name, ephemeral-pubkey, auth-response]
+    auth-header      = [auth-tag, id-nonce, auth-scheme-name, ephemeral-pubkey, auth-response]
     auth-scheme-name = "gcm"
-    auth-response    = aesgcm_encrypt(auth-resp-key, zero-nonce, auth-response-pt, tag)
-    auth-response-pt = [id-nonce-sig, node-record]
+    auth-response    = aesgcm_encrypt(auth-resp-key, zero-nonce, auth-response-plain, "")
     zero-nonce       = 12 zero bytes
-    id-nonce-sig     = sign(static-node-key, sha256("discovery-id-nonce" || id-nonce))
-    static-node-key  = the private key used for record identity
     message          = aesgcm_encrypt(initiator-key, auth-tag, message-pt, tag || auth-header)
     message-pt       = message-type || message-data
     auth-tag         = AES-GCM nonce, 12 random bytes unique to message
@@ -239,7 +243,8 @@ PONG is the reply to PING.
 
 FINDNODE queries for nodes at the given logarithmic distance from the recipient's node ID.
 The node IDs of all nodes in the response must have a shared prefix length of `distance`
-with the recipient's node ID.
+with the recipient's node ID. A request with distance `0` should return the recipient's
+current record as the only result.
 
 ### NODES Response (0x04)
 
@@ -286,9 +291,10 @@ is to encrypt and authenticate them with a separate key.
 
 ### REGTOPIC Request (0x07)
 
-    message-data = [request-id, ticket]
+    message-data = [request-id, ticket, ENR]
     message-type = 0x07
     ticket       = supplied by TICKET response
+    node-record  = current node record of sender
 
 REGTOPIC registers the sender for the given topic with a ticket. The ticket must be valid
 and its waiting time must have elapsed before using the ticket.

--- a/discv5/discv5.md
+++ b/discv5/discv5.md
@@ -32,7 +32,7 @@ The specification has three parts:
 
 - [discv5-wire.md] defines the wire protocol.
 - [discv5-theory.md] describes the algorithms and data structures.
-- [discv5-rationale.md] **(outdated)** contains a design rationale and communication examples.
+- [discv5-rationale.md] contains the design rationale.
 
 ## Comparison With Other Discovery Mechanisms
 


### PR DESCRIPTION
The rationale is now up-to-date with the wire protocol. The 'scenario'
descriptions were removed because they were hard to maintain. All of
them were outdated because the handshake didn't exist when they were
written.

These changes were made to get the wire protocol spec up-to-date with
the Go implementation:

- WHOAREYOU no longer has a tag prefix because it could be used
  to recover the node's ID.
- auth-response-pt contains a protocol version number.
- node-record in auth-response-pt is `[]` if absent. The spec said
  it is sent if local seq is higher but didn't define the RLP encoding.
- auth-header contains a reference to id-nonce prevent handshake replay.
- REGTOPIC requires sending the current node record.

Fixes #80 
Fixes #89 
Fixes #79