### PR TITLE
discv5: update discv5.md with the v5.1 version number

### DIFF
--- a/discv5/discv5.md
+++ b/discv5/discv5.md
@@ -1,6 +1,6 @@
 # Node Discovery Protocol v5
 
-**Draft of October 2019.**
+**Protocol version v5.1**
 
 Welcome to the Node Discovery Protocol v5 specification!
 


### PR DESCRIPTION
The other docs were updated to note `5.1` and this document still said it was a draft from 2019 Oct.
