### PR TITLE
caps/eth.md: specify encoding of all consensus objects

### DIFF
--- a/caps/eth.md
+++ b/caps/eth.md
@@ -235,7 +235,7 @@ identifier `receiptₙ`.
 Untyped, legacy receipts are encoded as follows:
 
     legacy-receipt = [
-        post-state-or-status: {{0, 1}, B_32},
+        post-state-or-status: {B_32, {0, 1}},
         cumulative-gas: P
         bloom: B_256,
         logs: [log₁, log₂, ...]

--- a/caps/eth.md
+++ b/caps/eth.md
@@ -214,7 +214,8 @@ transition, and the (weaker) 'data validity' of the block. The definition of sta
 transition rules is not dealt with in this specification. We require data validity of the
 block for the purposes of immediate [block propagation] and during [state synchronization].
 
-To determine the data validity of a block, use the rules below.
+To determine the data validity of a block, use the rules below. Implementations should
+disconnect peers sending invalid blocks.
 
 - The block `header` must be valid.
 - The `transactions` contained in the block must be valid for inclusion into the chain at

--- a/caps/eth.md
+++ b/caps/eth.md
@@ -129,7 +129,7 @@ Untyped, legacy transactions are given as an RLP list.
 [EIP-2718] typed transactions are encoded as RLP byte arrays where the first byte is the
 transaction type (`tx-type`) and the remaining bytes are opaque type-specific data.
 
-    typed-tx = rlp(tx-type || tx-data)
+    typed-tx = tx-type || tx-data
 
 Transactions must be validated when they are received. Validity depends on the Ethereum
 chain state. The specific kind of validity this specification is concerned with is not
@@ -258,7 +258,7 @@ Untyped, legacy receipts are encoded as follows:
 receipt type (matching `tx-type`) and the remaining bytes are opaque data specific to the
 type.
 
-    typed-receipt = rlp(tx-type || receipt-data)
+    typed-receipt = tx-type || receipt-data
 
 In the Ethereum Wire Protocol, receipts are always transferred as the complete list of all
 receipts contained in a block. It is also assumed that the block containing the receipts

--- a/caps/eth.md
+++ b/caps/eth.md
@@ -136,7 +136,7 @@ chain state. The specific kind of validity this specification is concerned with 
 whether the transaction can be executed successfully by the EVM, but only whether it is
 acceptable for temporary storage in the local pool and for exchange with other peers.
 
-Transactions must be validated according to the rules below. While the encoding of typed
+Transactions are validated according to the rules below. While the encoding of typed
 transactions is opaque, it is assumed that their `tx-data` provides values for `nonce`,
 `gas-price`, `gas-limit`, and that the sender account of the transaction can be determined
 from their signature.
@@ -145,12 +145,11 @@ from their signature.
   transaction types may be considered valid even before they become acceptable for
   inclusion in a block. Implementations should disconnect peers sending transactions of
   unknown type.
-- The signature (`V`, `R`, `S` values) must be valid according to the signature schemes
-  supported by the chain. For typed transactions, signature handling is defined by the EIP
-  introducing the type. For legacy transactions, the two schemes in active use are the
-  basic 'Homestead' scheme and the [EIP-155] scheme.
-- The `gas-limit` must cover the 'intrinsic gas' of the transaction, i.e. the base fee and
-  fee for the data size.
+- The signature must be valid according to the signature schemes supported by the chain.
+  For typed transactions, signature handling is defined by the EIP introducing the type.
+  For legacy transactions, the two schemes in active use are the basic 'Homestead' scheme
+  and the [EIP-155] scheme.
+- The `gas-limit` must cover the 'intrinsic gas' of the transaction.
 - The sender account of the transaction, which is derived from the signature, must have
   sufficient ether balance to cover the cost (`gas-limit * gas-price + value`) of the
   transaction.

--- a/caps/eth.md
+++ b/caps/eth.md
@@ -211,8 +211,8 @@ state transition validity is not dealt with in this specification. To determine 
 validity of a block, it must be validated against these rules:
 
 - The block header fields must be valid according to the definition above.
-- The `transactions` contained in the block must be valid according to the validation
-  rules given earlier.
+- The `transactions` contained in the block must be valid according to the rules given
+  earlier.
 - The sum of the `gas-limit`s of all transactions must not exceed the `gas-limit` of the
   block.
 - The `transactions` of the block must be verified against the `txs-root` by computing and

--- a/caps/eth.md
+++ b/caps/eth.md
@@ -365,11 +365,11 @@ The recommended soft limit for BlockBodies responses is 2 MiB.
 
 ### NewBlock (0x07)
 
-`[block, total-difficulty: P]`
+`[block, td: P]`
 
-Specify a single complete block that the peer should know about. `total-difficulty` is the
-total difficulty of the block, i.e. the sum of all block difficulties up to and including
-this block.
+Specify a single complete block that the peer should know about. `td` is the total
+difficulty of the block, i.e. the sum of all block difficulties up to and including this
+block.
 
 ### NewPooledTransactionHashes (0x08)
 

--- a/caps/eth.md
+++ b/caps/eth.md
@@ -236,7 +236,7 @@ Untyped, legacy receipts are encoded as follows:
 
     legacy-receipt = [
         post-state-or-status: {B_32, {0, 1}},
-        cumulative-gas: P
+        cumulative-gas: P,
         bloom: B_256,
         logs: [log₁, log₂, ...]
     ]


### PR DESCRIPTION
This adds a lot of new text to cover the encoding and validity of
consensus objects. We previously referred to the 'main Ethereum
specification' for that, but no such specification exists in practice.

There is also a new entry in the changelog to cover the addition of
EIP-2718 typed transactions in the wire protocol. 

Fixes #160 