### PR TITLE
discv5: specify endianness of XOR distance

### DIFF
--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -16,7 +16,7 @@ Node Discovery Protocol, and nodes using different schemes can communicate.
 
 The identity scheme of a node record defines how a 32-byte 'node ID' is derived from the
 information contained in the record. The 'distance' between two node IDs is the bitwise
-XOR of the IDs, taken as the number.
+XOR of the IDs, taken as the big-endian number.
 
     distance(n₁, n₂) = n₁ XOR n₂
 


### PR DESCRIPTION
Specify that the XOR distance, when taken as a number, is the big-endian number.

This seems to be true for all implementations, but this is not specified.

- [ChainSafe](https://github.com/ChainSafe/discv5/blob/master/src/kademlia/util.ts#L11)
- [Status](https://github.com/status-im/nim-eth/blob/master/eth/p2p/kademlia.nim#L55)
- [Sigma Prime](https://github.com/sigp/discv5/blob/master/src/kbucket/key.rs#L81)
  - [U256](https://github.com/paritytech/parity-common/blob/master/uint/src/uint.rs#L1368)