### PR TITLE
discv4: fix definition of node k-bucket distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We have several specifications for low-level protocols:
 
 The repository also contains specifications of many RLPx-based application-level protocols:
 
-- [Ethereum Wire Protocol] (eth/66)
+- [Ethereum Wire Protocol] (eth/67)
 - [Ethereum Snapshot Protocol] (snap/1)
 - [Light Ethereum Subprotocol] (les/4)
 - [Parity Light Protocol] (pip/1)

--- a/discv4.md
+++ b/discv4.md
@@ -31,9 +31,9 @@ from the response.
 ## Kademlia Table
 
 Nodes in the Discovery Protocol keep information about other nodes in their neighborhood.
-Neighbor nodes are stored in a routing table consisting of 'k-buckets'. For each `0 < i ≤
-256`, every node keeps a k-bucket of nodes with distance `[2i-1, 2i]` from
-itself.
+Neighbor nodes are stored in a routing table consisting of 'k-buckets'. For each `i` in
+`0 ≤ i < 256`, every node keeps a k-bucket of neighbors with distance
+`2^i ≤ distance < 2^(i+1)` from itself.
 
 The Node Discovery Protocol uses `k = 16`, i.e. every k-bucket contains up to 16 node
 entries. The entries are sorted by time last seen — least-recently seen node at the head,

--- a/discv4.md
+++ b/discv4.md
@@ -31,8 +31,8 @@ from the response.
 ## Kademlia Table
 
 Nodes in the Discovery Protocol keep information about other nodes in their neighborhood.
-Neighbor nodes are stored in a routing table consisting of 'k-buckets'. For each `0 ≤ i <
-256`, every node keeps a k-bucket for nodes of distance between `2i` and `2i+1` from
+Neighbor nodes are stored in a routing table consisting of 'k-buckets'. For each `0 < i ≤
+256`, every node keeps a k-bucket of nodes with distance `[2i-1, 2i]` from
 itself.
 
 The Node Discovery Protocol uses `k = 16`, i.e. every k-bucket contains up to 16 node


### PR DESCRIPTION
Restricting `i` to `[0, 256)` suggests that max XOR distance representable by a k-bucket is `[510, 511]` (when `i=255`). Given that a node public key is 512 bits (64 bytes), this means that if the first bit doesn't match (XOR distance of 512, half of all nodes), it cannot be stored in a k-bucket. Another minor issue is that the `i=0` bucket represents distances `[0, 1]`, but a node is only at distance 0 from itself?

I believe the author implied i's range to be `(0, 256]`, with each k-bucket representing distances in `[2i-1, 2i]`. This way, the `i=256` bucket represents distances `[511, 512]`, and the `i=1` bucket represents `[1, 2]`.