### PR TITLE
Update wire protocol

### DIFF
--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -20,7 +20,7 @@ XOR of the IDs, taken as the big-endian number.
 
     distance(n₁, n₂) = n₁ XOR n₂
 
-In many situations, the logarithmic distance (i.e. length of common prefix in bits) is
+In many situations, the logarithmic distance (i.e. length of differing suffix in bits) is
 used in place of the actual distance.
 
     logdistance(n₁, n₂) = log2(distance(n₁, n₂))


### PR DESCRIPTION
Changes to the wire protocol have come about since the the [TOPDISC paper](https://github.com/harnen/service-discovery-paper). The ADNODES response was deemed necessary to tell apart the double set of inbound NODES responses to a TOPICQUERY as according to the paper, once with advertised nodes and once with nodes to fill the topic's kbuckets. An implementation currently in review https://github.com/sigp/discv5/pull/126.