### PR TITLE
caps/eth.md: update for EIP-7642 (eth/69)

### DIFF
--- a/caps/eth.md
+++ b/caps/eth.md
@@ -1,7 +1,7 @@
 # Ethereum Wire Protocol (ETH)
 
 'eth' is a protocol on the [RLPx] transport that facilitates exchange of Ethereum
-blockchain information between peers. The current protocol version is **eth/68**. See end
+blockchain information between peers. The current protocol version is **eth/69**. See end
 of document for a list of changes in past protocol versions.
 
 ### Basic Operation
@@ -251,39 +251,30 @@ disconnect peers sending invalid blocks.
 
 ### Receipt Encoding and Validity
 
-Receipts are the output of the EVM state transition of a block. Like transactions,
-receipts have two distinct encodings and we will refer to either encoding using the
-identifier `receiptₙ`.
+Receipts are the output of the EVM state transition of a transaction.
 
-    receipt = {legacy-receipt, typed-receipt}
-
-Untyped, legacy receipts are encoded as follows:
-
-    legacy-receipt = [
-        post-state-or-status: {B_32, {0, 1}},
-        cumulative-gas: P,
-        bloom: B_256,
+    receiptₙ = [
+        tx-type: P,
+        status: B,
+        gas-used: P,
         logs: [log₁, log₂, ...]
     ]
-    log = [
-        contract-address: B_20,
+    logₙ = [
+        address: B_20,
         topics: [topic₁: B, topic₂: B, ...],
         data: B
     ]
-
-[EIP-2718] typed receipts are encoded as RLP byte arrays where the first byte gives the
-receipt type (matching `tx-type`) and the remaining bytes are opaque data specific to the
-type.
-
-    typed-receipt = tx-type || receipt-data
 
 In the Ethereum Wire Protocol, receipts are always transferred as the complete list of all
 receipts contained in a block. It is also assumed that the block containing the receipts
 is valid and known. When a list of block receipts is received by a peer, it must be
 verified by computing and comparing the merkle trie hash of the list against the
-`receipts-root` of the block. Since the valid list of receipts is determined by the EVM
-state transition, it is not necessary to define any further validity rules for receipts in
-this specification.
+`receipts-root` of the block. Note that in order to perform this verification, the
+receipts need to be re-encoded into the format used by the Ethereum consensus protocol,
+and their bloom filter has to be recomputed.
+
+Since the valid list of receipts is determined by the EVM state transition, it is not
+necessary to define any further validity rules for receipts in this specification.
 
 ## Protocol Messages
 
@@ -293,17 +284,23 @@ peer must mirror the value in the `request-id` element of the response message.
 
 ### Status (0x00)
 
-`[version: P, networkid: P, td: P, blockhash: B_32, genesis: B_32, forkid]`
+`[vsn: P, networkID: P, genesis: B_32, forkid, earliest: P, latest: P, latestHash: B_32]`
 
-Inform a peer of its current state. This message should be sent just after the connection
-is established and prior to any other eth protocol messages.
+This is the initial message, informing the peer about the local node state and
+configuration. This message should be sent just after the connection is established and
+prior to any other eth protocol messages.
 
-- `version`: the current protocol version
-- `networkid`: integer identifying the blockchain, see table below
-- `td`: total difficulty of the best chain. Integer, as found in block header.
-- `blockhash`: the hash of the best (i.e. highest TD) known block
+- `vsn`: the current protocol version
+- `networkID`: integer identifying the blockchain, see table below
 - `genesis`: the hash of the genesis block
 - `forkid`: An [EIP-2124] fork identifier, encoded as `[fork-hash, fork-next]`.
+
+The Status message also announces the available block range. See [BlockRangeUpdate] for
+more information.
+
+- `earliest`: number of the earliest available full block
+- `latest`: number of the latest available full block number
+- `latestHash`: hash of the latest available full block
 
 This table lists common Network IDs and their corresponding networks. Other IDs exist
 which aren't listed, i.e. clients should not require that any particular network ID is
@@ -464,7 +461,28 @@ contain the complete list of receipts of the block.
 
 The recommended soft limit for Receipts responses is 2 MiB.
 
+### BlockRangeUpdate (0x11)
+
+`[earliestBlock: P, latestBlock: P, latestBlockHash: B_32]`
+
+This is a notification about a change in the available block range on a peer.
+
+With this message, the peer announces that all blocks `b` with `earliestBlock >= b >=
+latestBlock` are available via [GetBlockBodies], and also that receipts for these blocks
+are available via [GetReceipts]. Headers are always assumed to be available for the full
+range of blocks from genesis.
+
+The notification doesn't need to be sent for every update to the node's head block. It is
+recommended to send an update about once every two minutes.
+
 ## Change Log
+
+### eth/69 ([EIP-7642], April 2025)
+
+Version 69 changed the [Status] message to include information about the available block
+range. A new [BlockRangeUpdate] message was added to notify peers about changes in block
+range. The [Receipts] message was changed to simplify the encoding of typed receipts and
+to remove the bloom filter.
 
 ### eth/68 ([EIP-5793], October 2022)
 
@@ -584,6 +602,7 @@ Version numbers below 60 were used during the Ethereum PoC development phase.
 [EIP-4895]: https://eips.ethereum.org/EIPS/eip-4895
 [EIP-4938]: https://eips.ethereum.org/EIPS/eip-4938
 [EIP-5793]: https://eips.ethereum.org/EIPS/eip-5793
+[EIP-7642]: https://eips.ethereum.org/EIPS/eip-7642
 [The Merge]: https://eips.ethereum.org/EIPS/eip-3675
 [London hard fork]: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
 [Shanghai fork]: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md


### PR DESCRIPTION
This defines protocol version eth/69, adding changes from https://eips.ethereum.org/EIPS/eip-7642