### PR TITLE
discv5: fix HKDF-Extract argument order in key derivation

### DIFF
--- a/discv5/discv5-theory.md
+++ b/discv5/discv5-theory.md
@@ -109,10 +109,14 @@ function.
     dest-pubkey        = public key corresponding to node B's static private key
     secret             = ecdh(dest-pubkey, ephemeral-key)
     kdf-info           = "discovery v5 key agreement" || node-id-A || node-id-B
-    prk                = HKDF-Extract(secret, challenge-data)
+    prk                = HKDF-Extract(challenge-data, secret)
     key-data           = HKDF-Expand(prk, kdf-info)
     initiator-key      = key-data[:16]
     recipient-key      = key-data[16:]
+
+Here `HKDF-Extract(salt, IKM)` and `HKDF-Expand` are the functions defined in [RFC 5869]
+using HMAC-SHA-256. The salt is `challenge-data` and the input keying material is `secret`;
+`HKDF-Expand` is invoked with `kdf-info` and produces 32 bytes of output.
 
 Node A creates the `id-signature`, which proves that it controls the private key which
 signed its node record. The signature also prevents replay of the handshake.
@@ -535,3 +539,4 @@ registration algorithm if the same topic is being registered and searched for.
 [REGTOPIC]: ./discv5-wire.md#regtopic-request-0x07
 [REGCONFIRMATION]: ./discv5-wire.md#regconfirmation-response-0x09
 [TOPICQUERY]: ./discv5-wire.md#topicquery-request-0x0a
+[RFC 5869]: https://www.rfc-editor.org/rfc/rfc5869


### PR DESCRIPTION
The handshake key-derivation step in `discv5-theory.md` is written as:

    prk = HKDF-Extract(secret, challenge-data)

[RFC 5869](https://www.rfc-editor.org/rfc/rfc5869) defines `HKDF-Extract(salt, IKM)`
with the salt first (`PRK = HMAC-Hash(salt, IKM)`). Discovery v5 uses
`salt = challenge-data` and `IKM = secret` (the ECDH output), so the two arguments
are written in the reverse order. `HKDF-Extract` / `HKDF-Expand` are also never
defined in the spec, which leaves the salt/IKM roles ambiguous.

This matters for anyone implementing from the spec text alone: mapping the formula
onto a standard `HKDF-Extract(salt, IKM)` API in the written order derives the wrong
session keys and fails the spec's own published test vector.

The Key Derivation test vector in `discv5-wire-test-vectors.md` reproduces only with
`salt = challenge-data`, `IKM = secret`:

    initiator-key = 0xdccc82d81bd610f4f76d3ebe97a40571
    recipient-key = 0xac74bb8773749920b0d3a8881c173ec5

The reversed order produces `initiator-key = 0xf742efec...`, which does not match.
go-ethereum's `deriveKeys` (`p2p/discover/v5wire/crypto.go`) likewise passes the ECDH
secret as the IKM and `challenge-data` as the salt.

This corrects the argument order and adds a short note pinning `HKDF-Extract` /
`HKDF-Expand` to RFC 5869 (HMAC-SHA-256, `salt = challenge-data`, `IKM = secret`,
32-byte output) so the roles can't be misread again.