### PR TITLE
caps/eth: define the pooled transaction encoding and fix the txsize definition

### DIFF
--- a/caps/eth.md
+++ b/caps/eth.md
@@ -173,8 +173,9 @@ observing `AVAILABILITY_THRESHOLD` distinct full-availability announcements.
 
 ### Transaction Encoding and Validity
 
-Transaction objects exchanged by peers have one of two encodings. In definitions across
-this specification, we refer to transactions of either encoding using the identifier `txₙ`.
+Transaction objects exchanged by peers may be encoded in more than one way. In definitions
+across this specification, we refer to transactions as they appear in blocks using the
+identifier `txₙ`.
 
     tx = {legacy-tx, typed-tx}
 
@@ -196,6 +197,38 @@ Untyped, legacy transactions are given as an RLP list.
 transaction type (`tx-type`) and the remaining bytes are opaque type-specific data.
 
     typed-tx = tx-type || tx-data
+
+#### Pooled Encoding
+
+Certain transaction types carry auxiliary data which is required to validate the
+transaction in the pool, but which is not part of the transaction as it appears in a
+block. Transactions of such a type therefore have a second, 'pooled' encoding, used by
+[PooledTransactions]. In definitions across this specification, we refer to transactions
+in this encoding using the identifier `pooled-txₙ`.
+
+For a transaction whose `tx-type` defines no wrapped form, the pooled encoding is
+identical to `tx`. Types which do define one — currently only type `0x03`, introduced by
+[EIP-4844] — are encoded as:
+
+    wrapped-tx = tx-type || rlp([
+        tx-payload-body,
+        wrapper-version: P,
+        blobs: [blob₁: B_131072, blob₂: B_131072, ...],
+        commitments: [commitment₁: B_48, commitment₂: B_48, ...],
+        proofs: [proof₁: B_48, proof₂: B_48, ...],
+    ])
+
+`tx-payload-body` is the transaction's `tx-data` decoded as an RLP list. `wrapper-version`
+selects the meaning of `proofs` and is defined by [EIP-7594]; the current version is `1`,
+for which `proofs` contains `CELLS_PER_EXT_BLOB` cell proofs per blob. On chains where
+[EIP-7594] is not active, the version-0 wrapper defined by [EIP-4844] is used instead: it
+omits the `wrapper-version` element and carries one blob proof per blob. The two forms are
+distinguished by the number of elements in the RLP list.
+
+The `blobs` element is the empty list in [PooledTransactions] responses from `eth/72`
+onwards; blob data is obtained through [GetCells] instead. See [EIP-8070]. Note that the
+resulting encoding still contains the `wrapper-version` element and an empty `blobs` list,
+so its length is not simply the length of the blob data subtracted from the unelided form.
 
 Transactions must be validated when they are received. Validity depends on the Ethereum
 chain state. The specific kind of validity this specification is concerned with is not
@@ -226,7 +259,7 @@ from their signature.
   current account nonce are valid, and to which degree 'nonce gaps' are acceptable.
 
 Implementations may enforce other validation rules for transactions. For example, it is
-common practice to reject encoded transactions larger than 128 kB.
+common practice to reject transactions whose `tx` encoding is larger than 128 kB.
 
 Unless noted otherwise, implementations must not disconnect peers for sending invalid
 transactions, and should simply discard them instead. This is because the peer might be
@@ -462,6 +495,10 @@ relay transactions to a peer they received that transaction from. In practice th
 often implemented by keeping a per-peer bloom filter or set of transaction hashes which
 have already been sent or received.
 
+Transactions of a type which defines a wrapped [pooled encoding] must not be sent in this
+message. Per [EIP-4844], such transactions are only ever announced with
+[NewPooledTransactionHashes] and served on request via [GetPooledTransactions].
+
 ### GetBlockHeaders (0x03)
 
 `[request-id: P, [startblock: {P, B_32}, limit: P, skip: P, reverse: {0, 1}]]`
@@ -521,9 +558,25 @@ The `txtypes` element is a byte array containing the announced [transaction type
 other two payload elements refer to the sizes and hashes of the announced transactions.
 All three payload elements must contain an equal number of items.
 
-`txsizeₙ` refers to the length of the 'consensus encoding' of a typed transaction, i.e.
-the byte size of `tx-type || tx-data` for typed transactions, and the size of the
-RLP-encoded `legacy-tx` for non-typed legacy transactions.
+`txsizeₙ` is the byte length of the announced transaction in the [pooled encoding], on the
+protocol version negotiated for this connection. It is the length of:
+
+- the RLP encoding of `legacy-tx`, for legacy transactions;
+- `tx-type || tx-data`, for typed transactions whose type defines no wrapped form;
+- the whole `wrapped-tx`, for types which do.
+
+The RLP string header which frames a typed transaction as an element of the enclosing
+[PooledTransactions] list is not counted.
+
+A peer must announce the size of the transaction it holds. A receiver may recompute
+`txsizeₙ` from a transaction it has been served — evaluating it at the protocol version on
+which the announcement was made, which need not be the version it was delivered on — and
+may disconnect a peer whose announcement disagrees. Announcing a transaction and then
+declining to serve it is not a disagreement; see [PooledTransactions].
+
+`txsizeₙ` accounts only for the [PooledTransactions] response. Data fetched separately, in
+particular cells fetched via [GetCells] from `eth/72` onwards, is not included; the `cells`
+element signals that availability instead.
 
 The `cells` element is a bitmap marking which cell indices can be fetched from the sending
 peer. For each bit set to one, the peer stores the cells at that index in every blob of
@@ -550,15 +603,10 @@ must not be considered a protocol violation.
 
 ### PooledTransactions (0x0a)
 
-`[request-id: P, [tx₁, tx₂...]]`
+`[request-id: P, [pooled-tx₁, pooled-tx₂, ...]]`
 
 This is the response to GetPooledTransactions, returning the requested transactions from
-the local pool. The items in the list are transactions in the format described in the main
-Ethereum specification.
-
-For blob transactions (type 3), the blob data is elided from the response.
-
-<!-- TODO: define encoding in tx section -->
+the local pool, in the [pooled encoding].
 
 The transactions must be in same order as in the request, but it is OK to skip
 transactions which are not available. This way, if the response size limit is reached,
@@ -832,6 +880,7 @@ Version numbers below 60 were used during the Ethereum PoC development phase.
 [NewPooledTransactionHashes]: #newpooledtransactionhashes-0x08
 [GetPooledTransactions]: #getpooledtransactions-0x09
 [PooledTransactions]: #pooledtransactions-0x0a
+[pooled encoding]: #pooled-encoding
 [GetReceipts]: #getreceipts-0x0f
 [Receipts]: #receipts-0x10
 [BlockRangeUpdate]: #blockrangeupdate-0x11


### PR DESCRIPTION
## Problem

The `txsize` definition is unambiguous for every transaction type **except type 3**, and type 3 is the only one where the number is large enough to matter.

https://github.com/ethereum/devp2p/blob/2c19a28b25c29487773ad6b07243e290fa8d65ec/caps/eth.md#L524-L526

For legacy, and for typed transactions of types `0x01`, `0x02`, `0x04`, there is exactly one candidate byte string, everyone agrees, and go-ethereum's `Transaction.MarshalBinary` implements precisely what the sentence says. **No change is proposed to that behaviour.**

The problem is that for type 3, `tx-data` is not a single well-defined byte string. [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#networking) defines a *networking wrapper* which is also of the form `0x03 || rlp(...)`, and go-ethereum's own `MarshalBinary` emits it whenever a sidecar is attached — which, in the pool, it always is:

```go
// core/types/tx_blob.go:342
func (tx *BlobTx) encode(b *bytes.Buffer) error {
	switch {
	case tx.Sidecar == nil:
		return rlp.Encode(b, tx)                          // ~157 B  (bare body)
	case tx.Sidecar.Version == BlobSidecarVersion0:
		return rlp.Encode(b, &blobTxWithBlobsV0{...})      // ~131 KB (4-element wrapper)
	case tx.Sidecar.Version == BlobSidecarVersion1:
		return rlp.Encode(b, &blobTxWithBlobsV1{...})      // ~137 KB (5-element wrapper)
	}
}
```

So `MarshalBinary` — the reference implementation of "the consensus encoding" — returns three different answers for one transaction depending on runtime state. The spec sentence does not say which one `txsize` means, because it was written before there was more than one.

What go-ethereum actually announces is not `MarshalBinary` at all, but a size carried on the pool metadata (`eth/protocols/eth/broadcast.go:140-144`), and its own field comments name the quantity:

```go
// core/txpool/subpool.go:89
type TxMetadata struct {
	Type            uint8
	Size            uint64 // The length of the 'rlp encoding' of a transaction (including blobs)
	SizeWithoutBlob uint64 // The length without blob data (for ETH/72 announcements)
}
```

`Size` — used on `eth/68`–`eth/71` — is documented as *including blobs*, which is by definition not the consensus encoding. `SizeWithoutBlob` — used from `eth/72` — is a third quantity again, and is computed arithmetically rather than by serializing anything (`core/txpool/blobpool/blobpool.go:202-213`).

So for a single-blob transaction there are **three** defensible readings of the current sentence, and clients have picked all three:

| value | what it is | who announces it |
|---:|---|---|
| **157** | bare consensus body, `Sidecar == nil` | Nethermind (reading the sentence literally) |
| **6,487** | eth/72 blob-elided wrapper | go-ethereum on `eth/72`; what it *expects* from an `eth/72` peer |
| **137,567** | full v1 network wrapper | go-ethereum on `eth/68`–`eth/71`; what it *expects* from a pre-`eth/72` peer |

Every one of those is `tx-type || tx-data` for some meaning of `tx-data`. That is the ambiguity this PR closes.

The document also contradicts itself 35 lines later: `PooledTransactions` says blob data is elided from the response, and then declines to define the resulting encoding at all:

https://github.com/ethereum/devp2p/blob/2c19a28b25c29487773ad6b07243e290fa8d65ec/caps/eth.md#L559-L561

## This is not hypothetical

On a 7-client devnet over four days, one client implemented `:524` literally and announced the consensus size on `eth/72`. go-ethereum expected the blob-elided size, saw a 6,330-byte discrepancy, and called `dropPeer()` **55,130 times — 61.5% of all announced-size disconnects on the network**. That pairing was reduced to roughly one surviving link per 225 peer slots.

The client is not obviously at fault: it implemented the sentence in this document, and its in-code comment says so.

## Changes

- Add a **Pooled Encoding** section defining the wrapped form. It is written generically ("types which define a wrapped form") rather than for type `0x03` specifically, so that a further blob-carrying type — e.g. [EIP-8141](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8141.md), which reuses the EIP-7594 wrapper unchanged — does not invalidate it.
- Describe **both** the EIP-4844 version-0 and EIP-7594 version-1 wrappers. These are two independent axes that are easy to conflate: the **wrapper shape follows the active fork**, while **blob elision follows the negotiated protocol version**. go-ethereum still models both (`blobTxWithBlobsV0`/`V1`, discriminated by RLP list arity).
- Redefine `txsize` as the length of that encoding, stating the stable rule once and the per-type detail separately.
- State explicitly that **the RLP string header framing a typed transaction inside the response list is not counted** — this matches what implementations compute (`Size()` adds only `+1` for the type byte) and would otherwise be ambiguous.
- Express the announce/serve requirement as a property of the announcer's computation *at the announcement's protocol version*, mirroring go-ethereum's `sizeForVersion`, rather than as an equality between two observed byte counts. A raw equality would make legitimate wrapper-upgrade behaviour a protocol violation.
- Fill the `TODO: define encoding in tx section`.
- Incidental, while in the file: disambiguate the "128 kB" rule now that two encodings are named, and record the EIP-4844 requirement that blob transactions are never broadcast via `Transactions (0x02)` — a rule that appears nowhere in this document today.

## Forward compatibility

The structure deliberately separates a stable, encoding-agnostic invariant from per-version detail. Checked against three live drafts:

- **[EIP-8094](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8094.md)** (sidecars removed from `PooledTransactions` entirely) — `txsize` collapses back to the plain consensus size; the invariant needs **zero edits**.
- **EIP-8141** (`FRAME_TX_TYPE = 0x06` carrying blobs) — covered by the generic wording.
- **SSZ transactions** (EIP-6404 et al.) — no SSZ EIP currently defines an announcement size or a pooled representation, so there is nothing to conflict with. Serialized length remains well-defined and cheap to compute, and EIP-7495's rename to `ProgressiveContainer` removed the "same value, two lengths" hazard.

Under an unambiguous definition, the 8-byte comparison tolerance in go-ethereum — commented *"due to the RLP vs consensus format messyness"* with `TODO(karalabe): Get rid of this relaxation when clients are proven stable` — could eventually be removed.

## Background

Full write-up of how this was found, including the byte arithmetic and the per-client breakdown: https://panda-uploads-production.devops-539.workers.dev/panda/uploads/a7974b/teardown.html

The markdown linter (`.lint/lint.sh caps/eth.md`) passes.


---

## Related PRs

This is one of four coordinated changes from the same investigation:

| | |
|---|---|
| **ethereum/devp2p#281** | the normative fix — `txsize` definition and the pooled encoding (this is the load-bearing one) |
| **ethereum/EIPs#12275** | non-normative signpost in EIP-8070 |
| **NethermindEth/nethermind#13049** | client fix — announces the consensus size on eth/72 (61.5% of observed disconnects) |
| **besu-eth/besu#11203** | client fix — announces the pre-upgrade v0 size while serving v1 on eth/71 (21.2%). Independent of the spec question; inconsistent under any reading |
| **lambdaclass/ethrex#7235** | client fix — announces an empty-bundle size when the sidecar is gone (16.7%) |
| **ethereum/go-ethereum#35620** | corrects a comment in `tx_fetcher.go` claiming geth "only warn[s], but doesn't drop" while calling `dropPeer` — the sentence that makes this behaviour easy to misread |

Suggested order: the spec change first, then the client fixes, then the EIP signpost.




## Client survey

All seven execution clients on the devnet were checked against the proposed definition. **The clarification breaks nobody**, and two clients are already exactly conformant:

| client | behaviour | verdict |
|---|---|---|
| **erigon** | announces `len(txBytes)` where `txBytes` is *the same buffer* it later serves | ✅ conformant by construction — effectively the reference implementation of this wording |
| **nimbus-eth1** | encodes exactly what it will serve | ✅ conformant by construction |
| go-ethereum | self-consistent; its `Size()` is a shortcut that coincides with the true length at blob scale | ✅ conformant |
| reth | announces the un-elided size on eth/72 | ❌ — already being fixed in paradigmxyz/reth#26574 |
| nethermind, besu, ethrex | see the table above | ❌ — PRs linked |

Two points that the wording above tries to make unambiguous, because they are exactly where implementations diverged:

1. The quantity is the **true length of the pooled encoding**, not any particular client's helper. go-ethereum's `Size()` computes `1 + P + S + hdr(S)` where the true length is `1 + P + S + hdr(P+S)`; these agree only because both headers are 4 bytes at realistic blob counts. erigon's and nimbus-eth1's are structural identities and are the better model.
2. Under `eth/72` the elided length still **includes** the `wrapper-version` element and the empty `blobs` list (`0xc0`). "Serialize with empty blobs" and "full size minus blob bytes" then give the same answer — which is worth stating rather than leaving implementers to rediscover.

